### PR TITLE
Ability to skip HTTP metrics reporting

### DIFF
--- a/httpserver/middleware/context.go
+++ b/httpserver/middleware/context.go
@@ -22,6 +22,7 @@ const (
 	ctxKeyLoggingParams
 	ctxKeyTraceID
 	ctxKeyRequestStartTime
+	ctxKeyHTTPMetricsStatus
 )
 
 func getStringFromContext(ctx context.Context, key ctxKey) string {
@@ -99,4 +100,28 @@ func NewContextWithRequestStartTime(ctx context.Context, startTime time.Time) co
 func GetRequestStartTimeFromContext(ctx context.Context) time.Time {
 	startTime, _ := ctx.Value(ctxKeyRequestStartTime).(time.Time)
 	return startTime
+}
+
+// NewContextWithHTTPMetricsEnabled creates a new context with special flag which can toggle HTTP metrics status.
+func NewContextWithHTTPMetricsEnabled(ctx context.Context) context.Context {
+	status := true
+	return context.WithValue(ctx, ctxKeyHTTPMetricsStatus, &status)
+}
+
+// IsHTTPMetricsEnabledInContext checks whether HTTP metrics are enabled in the context.
+func IsHTTPMetricsEnabledInContext(ctx context.Context) bool {
+	value := ctx.Value(ctxKeyHTTPMetricsStatus)
+	if value == nil {
+		return false
+	}
+	return *value.(*bool)
+}
+
+// DisableHTTPMetricsInContext disables HTTP metrics processing in the context.
+func DisableHTTPMetricsInContext(ctx context.Context) {
+	value := ctx.Value(ctxKeyHTTPMetricsStatus)
+	if value == nil {
+		return
+	}
+	*value.(*bool) = false
 }

--- a/httpserver/middleware/metrics.go
+++ b/httpserver/middleware/metrics.go
@@ -214,8 +214,14 @@ func (h *httpRequestMetricsHandler) ServeHTTP(rw http.ResponseWriter, r *http.Re
 	inFlightGauge.Inc()
 	defer inFlightGauge.Dec()
 
+	r = r.WithContext(NewContextWithHTTPMetricsEnabled(r.Context()))
+
 	wrw := WrapResponseWriterIfNeeded(rw, r.ProtoMajor)
 	defer func() {
+		if !IsHTTPMetricsEnabledInContext(r.Context()) {
+			return
+		}
+
 		if reqInfo.routePattern == "" {
 			reqInfo.routePattern = h.getRoutePattern(r)
 		}


### PR DESCRIPTION
A way to disable HTTP metrics reporting for specific requests has been developed.
Can be disabled in handler by:
`
middleware.DisableHTTPMetricsInContext(request.Context())
`
