### PR TITLE
Make metrics collection in throttle and middleware packages more flexible

### DIFF
--- a/httpserver/middleware/example_test.go
+++ b/httpserver/middleware/example_test.go
@@ -30,7 +30,7 @@ func Example() {
 		RequestBodyLimit(1024*1024, errDomain),
 	)
 
-	metricsCollector := NewHTTPRequestMetricsCollector()
+	metricsCollector := NewHTTPRequestPrometheusMetrics()
 	router.Use(HTTPRequestMetricsWithOpts(metricsCollector, getChiRoutePattern, HTTPRequestMetricsOpts{
 		ExcludedEndpoints: []string{"/metrics", "/healthz"}, // Metrics will not be collected for "/metrics" and "/healthz" endpoints.
 	}))

--- a/httpserver/middleware/throttle/example_test.go
+++ b/httpserver/middleware/throttle/example_test.go
@@ -157,16 +157,16 @@ rules:
 }
 
 func makeExampleTestServer(cfg *throttle.Config, longWorkDelay time.Duration) *httptest.Server {
-	throttleMetrics := throttle.NewMetricsCollector("")
-	throttleMetrics.MustRegister()
-	defer throttleMetrics.Unregister()
+	promMetrics := throttle.NewPrometheusMetrics()
+	promMetrics.MustRegister()
+	defer promMetrics.Unregister()
 
 	// Configure middleware that should do global throttling ("all_reqs" tag says about that).
-	allReqsThrottleMiddleware := throttle.MiddlewareWithOpts(cfg, apiErrDomain, throttleMetrics, throttle.MiddlewareOpts{
+	allReqsThrottleMiddleware := throttle.MiddlewareWithOpts(cfg, apiErrDomain, promMetrics, throttle.MiddlewareOpts{
 		Tags: []string{"all_reqs"}})
 
 	// Configure middleware that should do per-client throttling based on the username from basic auth ("authenticated_reqs" tag says about that).
-	authenticatedReqsThrottleMiddleware := throttle.MiddlewareWithOpts(cfg, apiErrDomain, throttleMetrics, throttle.MiddlewareOpts{
+	authenticatedReqsThrottleMiddleware := throttle.MiddlewareWithOpts(cfg, apiErrDomain, promMetrics, throttle.MiddlewareOpts{
 		Tags: []string{"authenticated_reqs"},
 		GetKeyIdentity: func(r *http.Request) (key string, bypass bool, err error) {
 			username, _, ok := r.BasicAuth()

--- a/httpserver/middleware/throttle/metrics.go
+++ b/httpserver/middleware/throttle/metrics.go
@@ -6,7 +6,9 @@ Released under MIT license.
 
 package throttle
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 const (
 	metricsLabelDryRun     = "dry_run"
@@ -19,70 +21,121 @@ const (
 	metricsValNo  = "no"
 )
 
-// MetricsCollector represents collector of metrics for rate/in-flight limiting rejects.
-type MetricsCollector struct {
+// MetricsCollector represents a collector of metrics for rate/in-flight limiting rejects.
+type MetricsCollector interface {
+	// IncInFlightLimitRejects increments the counter of rejected requests due to in-flight limit exceeded.
+	IncInFlightLimitRejects(ruleName string, dryRun bool, backlogged bool)
+
+	// IncRateLimitRejects increments the counter of rejected requests due to rate limit exceeded.
+	IncRateLimitRejects(ruleName string, dryRun bool)
+}
+
+// PrometheusMetricsOpts represents options for PrometheusMetrics.
+type PrometheusMetricsOpts struct {
+	// Namespace is a namespace for metrics. It will be prepended to all metric names.
+	Namespace string
+
+	// ConstLabels is a set of labels that will be applied to all metrics.
+	ConstLabels prometheus.Labels
+
+	// CurriedLabelNames is a list of label names that will be curried with the provided labels.
+	// See PrometheusMetrics.MustCurryWith method for more details.
+	// Keep in mind that if this list is not empty,
+	// PrometheusMetrics.MustCurryWith method must be called further with the same labels.
+	// Otherwise, the collector will panic.
+	CurriedLabelNames []string
+}
+
+// PrometheusMetrics represents a collector of Prometheus metrics for rate/in-flight limiting rejects.
+type PrometheusMetrics struct {
 	InFlightLimitRejects *prometheus.CounterVec
 	RateLimitRejects     *prometheus.CounterVec
 }
 
-// NewMetricsCollector creates a new instance of MetricsCollector.
-func NewMetricsCollector(namespace string) *MetricsCollector {
+// NewPrometheusMetrics creates a new instance of PrometheusMetrics.
+func NewPrometheusMetrics() *PrometheusMetrics {
+	return NewPrometheusMetricsWithOpts(PrometheusMetricsOpts{})
+}
+
+// NewPrometheusMetricsWithOpts creates a new instance of PrometheusMetrics with the provided options.
+func NewPrometheusMetricsWithOpts(opts PrometheusMetricsOpts) *PrometheusMetrics {
+	makeLabelNames := func(names ...string) []string {
+		l := append(make([]string, 0, len(opts.CurriedLabelNames)+len(names)), opts.CurriedLabelNames...)
+		return append(l, names...)
+	}
+
 	inFlightLimitRejects := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: namespace,
-		Name:      "in_flight_limit_rejects_total",
-		Help:      "Number of rejected requests due to in-flight limit exceeded.",
-	}, []string{metricsLabelDryRun, metricsLabelRule, metricsLabelBacklogged})
+		Namespace:   opts.Namespace,
+		Name:        "in_flight_limit_rejects_total",
+		Help:        "Number of rejected requests due to in-flight limit exceeded.",
+		ConstLabels: opts.ConstLabels,
+	}, makeLabelNames(metricsLabelDryRun, metricsLabelRule, metricsLabelBacklogged))
 
 	rateLimitRejects := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: namespace,
-		Name:      "rate_limit_rejects_total",
-		Help:      "Number of rejected requests due to rate limit exceeded.",
-	}, []string{metricsLabelDryRun, metricsLabelRule})
+		Namespace:   opts.Namespace,
+		Name:        "rate_limit_rejects_total",
+		Help:        "Number of rejected requests due to rate limit exceeded.",
+		ConstLabels: opts.ConstLabels,
+	}, makeLabelNames(metricsLabelDryRun, metricsLabelRule))
 
-	return &MetricsCollector{
+	return &PrometheusMetrics{
 		InFlightLimitRejects: inFlightLimitRejects,
 		RateLimitRejects:     rateLimitRejects,
 	}
 }
 
 // MustCurryWith curries the metrics collector with the provided labels.
-func (mc *MetricsCollector) MustCurryWith(labels prometheus.Labels) *MetricsCollector {
-	return &MetricsCollector{
-		InFlightLimitRejects: mc.InFlightLimitRejects.MustCurryWith(labels),
-		RateLimitRejects:     mc.RateLimitRejects.MustCurryWith(labels),
+func (pm *PrometheusMetrics) MustCurryWith(labels prometheus.Labels) *PrometheusMetrics {
+	return &PrometheusMetrics{
+		InFlightLimitRejects: pm.InFlightLimitRejects.MustCurryWith(labels),
+		RateLimitRejects:     pm.RateLimitRejects.MustCurryWith(labels),
 	}
 }
 
 // MustRegister does registration of metrics collector in Prometheus and panics if any error occurs.
-func (mc *MetricsCollector) MustRegister() {
+func (pm *PrometheusMetrics) MustRegister() {
 	prometheus.MustRegister(
-		mc.InFlightLimitRejects,
-		mc.RateLimitRejects,
+		pm.InFlightLimitRejects,
+		pm.RateLimitRejects,
 	)
 }
 
 // Unregister cancels registration of metrics collector in Prometheus.
-func (mc *MetricsCollector) Unregister() {
-	prometheus.Unregister(mc.InFlightLimitRejects)
-	prometheus.Unregister(mc.RateLimitRejects)
+func (pm *PrometheusMetrics) Unregister() {
+	prometheus.Unregister(pm.InFlightLimitRejects)
+	prometheus.Unregister(pm.RateLimitRejects)
 }
 
-func makeCommonPromLabels(dryRun bool, rule string) prometheus.Labels {
+// IncInFlightLimitRejects increments the counter of rejected requests due to in-flight limit exceeded.
+func (pm *PrometheusMetrics) IncInFlightLimitRejects(ruleName string, dryRun bool, backlogged bool) {
 	dryRunVal := metricsValNo
 	if dryRun {
 		dryRunVal = metricsValYes
 	}
-	return prometheus.Labels{metricsLabelDryRun: dryRunVal, metricsLabelRule: rule}
-}
-
-func makePromLabelsForInFlightLimit(commonLabels prometheus.Labels, backlogged bool) prometheus.Labels {
 	backloggedVal := metricsValNo
 	if backlogged {
 		backloggedVal = metricsValYes
 	}
-	return prometheus.Labels{
-		metricsLabelDryRun:     commonLabels[metricsLabelDryRun],
-		metricsLabelRule:       commonLabels[metricsLabelRule],
+	pm.InFlightLimitRejects.With(prometheus.Labels{
+		metricsLabelDryRun:     dryRunVal,
+		metricsLabelRule:       ruleName,
 		metricsLabelBacklogged: backloggedVal,
-	}
+	}).Inc()
 }
+
+// IncRateLimitRejects increments the counter of rejected requests due to rate limit exceeded.
+func (pm *PrometheusMetrics) IncRateLimitRejects(ruleName string, dryRun bool) {
+	dryRunVal := metricsValNo
+	if dryRun {
+		dryRunVal = metricsValYes
+	}
+	pm.RateLimitRejects.With(prometheus.Labels{
+		metricsLabelDryRun: dryRunVal,
+		metricsLabelRule:   ruleName,
+	}).Inc()
+}
+
+type disabledMetrics struct{}
+
+func (disabledMetrics) IncInFlightLimitRejects(string, bool, bool) {}
+func (disabledMetrics) IncRateLimitRejects(string, bool)           {}

--- a/httpserver/middleware/throttle/middleware_test.go
+++ b/httpserver/middleware/throttle/middleware_test.go
@@ -593,7 +593,7 @@ func makeHandlerWrappedIntoMiddleware(
 	cfg *Config, blockCh chan struct{}, tags []string, buildHandlerAtInit bool,
 ) (http.Handler, *testCounters) {
 	c := &testCounters{}
-	mid := MiddlewareWithOpts(cfg, testErrDomain, NewMetricsCollector(""), MiddlewareOpts{
+	mid := MiddlewareWithOpts(cfg, testErrDomain, NewPrometheusMetrics(), MiddlewareOpts{
 		GetKeyIdentity: func(r *http.Request) (key string, bypass bool, err error) {
 			username, _, ok := r.BasicAuth()
 			if !ok {

--- a/httpserver/router.go
+++ b/httpserver/router.go
@@ -74,7 +74,7 @@ func configureRouter(router chi.Router, logger log.FieldLogger, opts RouterOpts)
 
 // nolint // hugeParam: opts is heavy, it's ok in this case.
 func applyDefaultMiddlewaresToRouter(
-	router chi.Router, cfg *Config, logger log.FieldLogger, opts Opts, metricsCollector *middleware.HTTPRequestMetricsCollector,
+	router chi.Router, cfg *Config, logger log.FieldLogger, opts Opts, promMetrics *middleware.HTTPRequestPrometheusMetrics,
 ) error {
 	router.Use(func(handler http.Handler) http.Handler {
 		return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
@@ -109,7 +109,7 @@ func applyDefaultMiddlewaresToRouter(
 		// Custom route pattern parser
 		getRoutePattern = opts.HTTPRequestMetrics.GetRoutePattern
 	}
-	metricsMiddleware := middleware.HTTPRequestMetricsWithOpts(metricsCollector, getRoutePattern,
+	metricsMiddleware := middleware.HTTPRequestMetricsWithOpts(promMetrics, getRoutePattern,
 		middleware.HTTPRequestMetricsOpts{
 			GetUserAgentType:  opts.HTTPRequestMetrics.GetUserAgentType,
 			ExcludedEndpoints: systemEndpoints,


### PR DESCRIPTION
Now middlewares receive interfaces instead of the concrete Prometheus implementations.

This change is a breaking change. However, given the library’s current limited usage, we have decided not to bump the major version at this time.