### PR TITLE
Avoid implicit panics in middleware and middleware/throttle packages

### DIFF
--- a/httpserver/config.go
+++ b/httpserver/config.go
@@ -179,7 +179,7 @@ func NewConfig() *Config {
 }
 
 // NewConfigWithKeyPrefix creates a new instance of the Config.
-// Allows to specify key prefix which will be used for parsing configuration parameters.
+// Allows specifying key prefix which will be used for parsing configuration parameters.
 func NewConfigWithKeyPrefix(keyPrefix string) *Config {
 	return &Config{keyPrefix: keyPrefix}
 }

--- a/httpserver/http_server.go
+++ b/httpserver/http_server.go
@@ -25,9 +25,6 @@ import (
 	"github.com/acronis/go-appkit/service"
 )
 
-// ErrInvalidMaxServingRequests error is returned when maximum number of currently serving requests is negative.
-var ErrInvalidMaxServingRequests = errors.New("maximum number of currently serving requests must not be negative")
-
 const (
 	networkTCP  = "tcp"
 	networkUnix = "unix"

--- a/httpserver/middleware/example_test.go
+++ b/httpserver/middleware/example_test.go
@@ -35,7 +35,7 @@ func Example() {
 		ExcludedEndpoints: []string{"/metrics", "/healthz"}, // Metrics will not be collected for "/metrics" and "/healthz" endpoints.
 	}))
 
-	userCreateInFlightLimitMiddleware := InFlightLimitWithOpts(32, errDomain, InFlightLimitOpts{
+	userCreateInFlightLimitMiddleware := MustInFlightLimitWithOpts(32, errDomain, InFlightLimitOpts{
 		GetKey: func(r *http.Request) (string, bool, error) {
 			key := r.Header.Get("X-Client-ID")
 			return key, key == "", nil
@@ -49,7 +49,7 @@ func Example() {
 		BacklogTimeout: time.Second * 10,
 	})
 
-	usersListRateLimitMiddleware := RateLimit(Rate{Count: 100, Duration: time.Second}, errDomain)
+	usersListRateLimitMiddleware := MustRateLimit(Rate{Count: 100, Duration: time.Second}, errDomain)
 
 	router.Route("/users", func(r chi.Router) {
 		r.With(usersListRateLimitMiddleware).Get("/", func(rw http.ResponseWriter, req *http.Request) {

--- a/httpserver/middleware/in_flight_limit_test.go
+++ b/httpserver/middleware/in_flight_limit_test.go
@@ -45,7 +45,7 @@ func TestInFlightLimitHandler_ServeHTTP(t *testing.T) {
 			}
 			rw.WriteHeader(http.StatusOK)
 		})
-		handler := InFlightLimit(1, errDomain)(next)
+		handler := MustInFlightLimit(1, errDomain)(next)
 
 		respCode := make(chan int)
 		go func() {
@@ -84,7 +84,7 @@ func TestInFlightLimitHandler_ServeHTTP(t *testing.T) {
 			}
 			rw.WriteHeader(http.StatusOK)
 		})
-		handler := InFlightLimitWithOpts(1, errDomain, InFlightLimitOpts{BacklogLimit: 1, BacklogTimeout: backlogTimeout})(next)
+		handler := MustInFlightLimitWithOpts(1, errDomain, InFlightLimitOpts{BacklogLimit: 1, BacklogTimeout: backlogTimeout})(next)
 
 		resp1Code := make(chan int)
 		go func() {
@@ -139,7 +139,7 @@ func TestInFlightLimitHandler_ServeHTTP(t *testing.T) {
 			rw.WriteHeader(http.StatusOK)
 		})
 
-		handler := InFlightLimit(limit, errDomain)(next)
+		handler := MustInFlightLimit(limit, errDomain)(next)
 		var wg sync.WaitGroup
 		for i := 0; i < reqsNum; i++ {
 			wg.Add(1)
@@ -184,7 +184,7 @@ func TestInFlightLimitHandler_ServeHTTP(t *testing.T) {
 			}
 			rw.WriteHeader(http.StatusOK)
 		})
-		handler := InFlightLimitWithOpts(1, errDomain, InFlightLimitOpts{
+		handler := MustInFlightLimitWithOpts(1, errDomain, InFlightLimitOpts{
 			GetKey:             makeInFlightLimitGetKeyByHeader(headerClientID),
 			ResponseStatusCode: http.StatusTooManyRequests,
 		})(next)
@@ -235,7 +235,7 @@ func TestInFlightLimitHandler_ServeHTTP(t *testing.T) {
 			}
 			rw.WriteHeader(http.StatusOK)
 		})
-		handler := InFlightLimitWithOpts(1, errDomain, InFlightLimitOpts{
+		handler := MustInFlightLimitWithOpts(1, errDomain, InFlightLimitOpts{
 			GetKey: func(r *http.Request) (string, bool, error) {
 				key := r.Header.Get(headerClientID)
 				return key, key == "", nil
@@ -308,7 +308,7 @@ func TestInFlightLimitHandler_ServeHTTP(t *testing.T) {
 			}
 			rw.WriteHeader(http.StatusOK)
 		})
-		handler := InFlightLimitWithOpts(1, errDomain, InFlightLimitOpts{
+		handler := MustInFlightLimitWithOpts(1, errDomain, InFlightLimitOpts{
 			GetKey: func(r *http.Request) (string, bool, error) {
 				return r.Header.Get(headerClientID), false, nil
 			},
@@ -358,7 +358,7 @@ func TestInFlightLimitHandler_ServeHTTP(t *testing.T) {
 			rw.WriteHeader(http.StatusOK)
 		})
 
-		handler := InFlightLimitWithOpts(limitPerClient, errDomain, InFlightLimitOpts{
+		handler := MustInFlightLimitWithOpts(limitPerClient, errDomain, InFlightLimitOpts{
 			GetKey:             makeInFlightLimitGetKeyByHeader(headerClientID),
 			ResponseStatusCode: http.StatusTooManyRequests,
 		})(next)
@@ -417,7 +417,7 @@ func TestInFlightLimitHandler_ServeHTTP(t *testing.T) {
 			}
 			rw.WriteHeader(http.StatusOK)
 		})
-		handler := InFlightLimitWithOpts(1, errDomain, InFlightLimitOpts{
+		handler := MustInFlightLimitWithOpts(1, errDomain, InFlightLimitOpts{
 			GetKey:             makeInFlightLimitGetKeyByHeader(headerClientID),
 			MaxKeys:            1,
 			ResponseStatusCode: http.StatusTooManyRequests,
@@ -460,7 +460,7 @@ func TestInFlightLimitHandler_ServeHTTP(t *testing.T) {
 			rw.WriteHeader(http.StatusOK)
 		})
 
-		handler := InFlightLimitWithOpts(limit, errDomain, InFlightLimitOpts{
+		handler := MustInFlightLimitWithOpts(limit, errDomain, InFlightLimitOpts{
 			GetKey:             makeInFlightLimitGetKeyByHeader(headerClientID),
 			MaxKeys:            1,
 			ResponseStatusCode: http.StatusTooManyRequests,
@@ -499,7 +499,7 @@ func TestInFlightLimitHandler_ServeHTTP(t *testing.T) {
 			<-reqContinued
 			rw.WriteHeader(http.StatusOK)
 		})
-		handler := InFlightLimitWithOpts(1, errDomain, InFlightLimitOpts{GetRetryAfter: func(r *http.Request) time.Duration {
+		handler := MustInFlightLimitWithOpts(1, errDomain, InFlightLimitOpts{GetRetryAfter: func(r *http.Request) time.Duration {
 			return retryAfter
 		}})(next)
 
@@ -530,7 +530,7 @@ func TestInFlightLimitHandler_ServeHTTP(t *testing.T) {
 			rw.WriteHeader(http.StatusOK)
 		})
 
-		handler := InFlightLimitWithOpts(limit, errDomain, InFlightLimitOpts{
+		handler := MustInFlightLimitWithOpts(limit, errDomain, InFlightLimitOpts{
 			DryRun:         true,
 			BacklogLimit:   backlogLimit,
 			BacklogTimeout: time.Millisecond * 10,

--- a/httpserver/router.go
+++ b/httpserver/router.go
@@ -116,12 +116,11 @@ func applyDefaultMiddlewaresToRouter(
 		})
 	router.Use(metricsMiddleware)
 
-	// To limit the number of currently serving requests, we use Throttle middleware from chi.
-	if cfg.Limits.MaxRequests < 0 {
-		return ErrInvalidMaxServingRequests
-	}
-	if cfg.Limits.MaxRequests > 0 {
-		inFlightLimitMw := middleware.InFlightLimit(cfg.Limits.MaxRequests, opts.ErrorDomain)
+	if cfg.Limits.MaxRequests != 0 {
+		inFlightLimitMw, err := middleware.InFlightLimit(cfg.Limits.MaxRequests, opts.ErrorDomain)
+		if err != nil {
+			return fmt.Errorf("create in-flight limit middleware: %w", err)
+		}
 		router.Use(func(next http.Handler) http.Handler {
 			return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 				for i := 0; i < len(systemEndpoints); i++ {


### PR DESCRIPTION
This PR introduces a breaking change. However, due to the library’s limited current usage, we have decided not to increase the major version at this time.