### PR TITLE
Support for Standard YAML/JSON Unmarshaling in Configuration Loading

### DIFF
--- a/config/custom_types.go
+++ b/config/custom_types.go
@@ -1,0 +1,165 @@
+/*
+Copyright © 2024 Acronis International GmbH.
+
+Released under MIT license.
+*/
+
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"code.cloudfoundry.org/bytefmt"
+	"gopkg.in/yaml.v3"
+)
+
+// BytesCount represents a number of bytes that can be parsed from JSON and YAML.
+type BytesCount uint64
+
+// UnmarshalJSON allows decoding from both integers and human-readable strings.
+// Implements json.Unmarshaler interface.
+func (b *BytesCount) UnmarshalJSON(data []byte) error {
+	s := strings.Trim(string(data), `"`)
+	if num, err := strconv.ParseUint(s, 10, 64); err == nil {
+		*b = BytesCount(num)
+		return nil
+	}
+
+	if num, err := bytefmt.ToBytes(s); err == nil {
+		*b = BytesCount(num)
+		return nil
+	}
+
+	return fmt.Errorf("invalid bytes format: %s", s)
+}
+
+// UnmarshalYAML allows decoding from YAML.
+// Implements yaml.Unmarshaler interface.
+func (b *BytesCount) UnmarshalYAML(value *yaml.Node) error {
+	var raw string
+	if err := value.Decode(&raw); err == nil {
+		if num, err := bytefmt.ToBytes(raw); err == nil {
+			*b = BytesCount(num)
+			return nil
+		}
+	}
+
+	var num uint64
+	if err := value.Decode(&num); err == nil {
+		*b = BytesCount(num)
+		return nil
+	}
+
+	return fmt.Errorf("invalid bytes format: %v", value)
+}
+
+// UnmarshalText allows decoding from text.
+// Implements encoding.TextUnmarshaler interface, which is used by mapstructure.TextUnmarshallerHookFunc.
+func (b *BytesCount) UnmarshalText(text []byte) error {
+	return b.UnmarshalJSON(text)
+}
+
+// String returns the human-readable string representation.
+// Implements fmt.Stringer interface.
+func (b BytesCount) String() string {
+	return bytefmt.ByteSize(uint64(b))
+}
+
+// MarshalJSON encodes as a human-readable string in JSON.
+// Implements json.Marshaler interface.
+func (b BytesCount) MarshalJSON() ([]byte, error) {
+	return json.Marshal(b.String())
+}
+
+// MarshalYAML encodes as a human-readable string in YAML.
+// Implements yaml.Marshaler interface.
+func (b BytesCount) MarshalYAML() (interface{}, error) {
+	return b.String(), nil
+}
+
+// MarshalText encodes as a human-readable string in text.
+// Implements encoding.TextMarshaler interface.
+func (b *BytesCount) MarshalText() ([]byte, error) {
+	return []byte(b.String()), nil
+}
+
+// TimeDuration represents a time duration that can be parsed from JSON and YAML.
+type TimeDuration time.Duration
+
+// UnmarshalJSON allows decoding from both integers (milliseconds) and human-readable strings.
+// Implements json.Unmarshaler interface.
+func (d *TimeDuration) UnmarshalJSON(data []byte) error {
+	s := strings.Trim(string(data), `"`)
+	if num, err := strconv.ParseInt(s, 10, 64); err == nil {
+		if num < 0 {
+			return fmt.Errorf("negative value is not allowed: %d", num)
+		}
+		*d = TimeDuration(time.Duration(num) * time.Millisecond)
+		return nil
+	}
+
+	if dur, err := time.ParseDuration(s); err == nil {
+		*d = TimeDuration(dur)
+		return nil
+	}
+
+	return fmt.Errorf("invalid duration format: %s", s)
+}
+
+// UnmarshalYAML allows decoding from YAML.
+// Implements yaml.Unmarshaler interface.
+func (d *TimeDuration) UnmarshalYAML(value *yaml.Node) error {
+	var raw string
+	if err := value.Decode(&raw); err == nil {
+		var dur time.Duration
+		if dur, err = time.ParseDuration(raw); err == nil {
+			*d = TimeDuration(dur)
+			return nil
+		}
+	}
+
+	var num int64
+	if err := value.Decode(&num); err == nil {
+		if num < 0 {
+			return fmt.Errorf("negative value is not allowed: %d", num)
+		}
+		*d = TimeDuration(time.Duration(num) * time.Millisecond)
+		return nil
+	}
+
+	return fmt.Errorf("invalid duration format: %v", value)
+}
+
+// UnmarshalText allows decoding from text.
+// Implements encoding.TextUnmarshaler interface, which is used by mapstructure.TextUnmarshallerHookFunc.
+func (d *TimeDuration) UnmarshalText(text []byte) error {
+	return d.UnmarshalJSON(text)
+}
+
+// String returns the human-readable string representation.
+// Implements fmt.Stringer interface.
+func (d TimeDuration) String() string {
+	return time.Duration(d).String()
+}
+
+// MarshalJSON encodes as a human-readable string in JSON.
+// Implements json.Marshaler interface.
+func (d TimeDuration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.String())
+}
+
+// MarshalYAML encodes as a human-readable string in YAML.
+// Implements yaml.Marshaler interface.
+func (d TimeDuration) MarshalYAML() (interface{}, error) {
+	return d.String(), nil
+}
+
+// MarshalText encodes as a human-readable string in text.
+// Implements encoding.TextMarshaler interface.
+func (d TimeDuration) MarshalText() ([]byte, error) {
+	return []byte(d.String()), nil
+}

--- a/config/custom_types.go
+++ b/config/custom_types.go
@@ -58,7 +58,7 @@ func (b *ByteSize) UnmarshalYAML(value *yaml.Node) error {
 		*b = bs
 		return nil
 	}
-	return fmt.Errorf("invalid bytes format: %v", value)
+	return fmt.Errorf("invalid byte size format: %v", value)
 }
 
 // UnmarshalText allows decoding from text.
@@ -126,26 +126,17 @@ func (d *TimeDuration) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	if dur, err := time.ParseDuration(s); err == nil {
-		*d = TimeDuration(dur)
-		return nil
+	dur, err := time.ParseDuration(s)
+	if err != nil {
+		return fmt.Errorf("invalid time duration format (%s): %w", s, err)
 	}
-
-	return fmt.Errorf("invalid duration format: %s", s)
+	*d = TimeDuration(dur)
+	return nil
 }
 
 // UnmarshalYAML allows decoding from YAML and supports both integers (nanoseconds) and human-readable strings.
 // Implements yaml.Unmarshaler interface.
 func (d *TimeDuration) UnmarshalYAML(value *yaml.Node) error {
-	var raw string
-	if err := value.Decode(&raw); err == nil {
-		var dur time.Duration
-		if dur, err = time.ParseDuration(raw); err == nil {
-			*d = TimeDuration(dur)
-			return nil
-		}
-	}
-
 	var num int64
 	if err := value.Decode(&num); err == nil {
 		if num < 0 {
@@ -154,8 +145,16 @@ func (d *TimeDuration) UnmarshalYAML(value *yaml.Node) error {
 		*d = TimeDuration(num)
 		return nil
 	}
-
-	return fmt.Errorf("invalid duration format: %v", value)
+	var raw string
+	if err := value.Decode(&raw); err == nil {
+		dur, parseErr := time.ParseDuration(raw)
+		if parseErr != nil {
+			return fmt.Errorf("invalid time duration format (%s): %w", raw, parseErr)
+		}
+		*d = TimeDuration(dur)
+		return nil
+	}
+	return fmt.Errorf("invalid time duration format: %v", value)
 }
 
 // UnmarshalText allows decoding from text.

--- a/config/custom_types_test.go
+++ b/config/custom_types_test.go
@@ -27,6 +27,7 @@ func TestByteSize_UnmarshalJSON(t *testing.T) {
 		{"Valid Human-Readable, MiB", `"10MiB"`, ByteSize(10 * 1024 * 1024), false},
 		{"Valid Human-Readable, k8s format, Mi", `"10Mi"`, ByteSize(10 * 1024 * 1024), false},
 		{"Invalid Format", `"invalid"`, 0, true},
+		{"Invalid Format, not a string", "{}", 0, true},
 		{"Negative Value", `"-1024"`, 0, true},
 	}
 	for _, tt := range tests {
@@ -55,6 +56,7 @@ func TestByteSize_UnmarshalYAML(t *testing.T) {
 		{"Valid Human-Readable, MiB", "size: 20MiB", ByteSize(20 * 1024 * 1024), false},
 		{"Valid Human-Readable, k8s format, Mi", "size: 20Mi", ByteSize(20 * 1024 * 1024), false},
 		{"Invalid Format", "size: invalid", 0, true},
+		{"Invalid Format, not a string", "size: {}", 0, true},
 		{"Negative Value", "size: -1024", 0, true},
 	}
 	for _, tt := range tests {
@@ -184,6 +186,7 @@ func TestTimeDuration_UnmarshalJSON(t *testing.T) {
 		{"Valid Integer", `1000000000`, TimeDuration(time.Second), false},
 		{"Valid Human-Readable", `"1s"`, TimeDuration(time.Second), false},
 		{"Invalid Format", `"invalid"`, 0, true},
+		{"Invalid Format, not a string", "{}", 0, true},
 		{"Negative Value", `"-1000"`, 0, true},
 	}
 	for _, tt := range tests {
@@ -210,6 +213,7 @@ func TestTimeDuration_UnmarshalYAML(t *testing.T) {
 		{"Valid Integer", "duration: 2000000000", TimeDuration(2 * time.Second), false},
 		{"Valid Human-Readable", "duration: 2s", TimeDuration(2 * time.Second), false},
 		{"Invalid Format", "duration: invalid", 0, true},
+		{"Invalid Format, not a string", "duration: {}", 0, true},
 		{"Negative Value", "duration: -2000", 0, true},
 	}
 	for _, tt := range tests {

--- a/config/custom_types_test.go
+++ b/config/custom_types_test.go
@@ -1,0 +1,296 @@
+/*
+Copyright © 2024 Acronis International GmbH.
+
+Released under MIT license.
+*/
+
+package config
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestBytesCount_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    BytesCount
+		wantErr bool
+	}{
+		{"Valid Integer", `1024`, BytesCount(1024), false},
+		{"Valid Human-Readable", `"10MB"`, BytesCount(10 * 1024 * 1024), false},
+		{"Invalid Format", `"invalid"`, 0, true},
+		{"Negative Value", `"-1024"`, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var b BytesCount
+			err := json.Unmarshal([]byte(tt.input), &b)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, b)
+			}
+		})
+	}
+}
+
+func TestBytesCount_UnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    BytesCount
+		wantErr bool
+	}{
+		{"Valid Integer", "size: 2048", BytesCount(2048), false},
+		{"Valid Human-Readable", "size: 20MB", BytesCount(20 * 1024 * 1024), false},
+		{"Invalid Format", "size: invalid", 0, true},
+		{"Negative Value", "size: -1024", 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg struct{ Size BytesCount }
+			err := yaml.Unmarshal([]byte(tt.input), &cfg)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, cfg.Size)
+			}
+		})
+	}
+}
+
+func TestBytesCount_UnmarshalText(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    BytesCount
+		wantErr bool
+	}{
+		{"Valid Integer", "4096", BytesCount(4096), false},
+		{"Valid Human-Readable", "20MB", BytesCount(20 * 1024 * 1024), false},
+		{"Invalid Format", "invalid", 0, true},
+		{"Negative Value", "-1024", 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var b BytesCount
+			err := b.UnmarshalText([]byte(tt.input))
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, b)
+			}
+		})
+	}
+}
+
+func TestBytesCount_String(t *testing.T) {
+	tests := []struct {
+		name  string
+		input BytesCount
+		want  string
+	}{
+		{"Bytes", BytesCount(512), "512B"},
+		{"Kilobytes", BytesCount(1024), "1K"},
+		{"Megabytes", BytesCount(2 * 1024 * 1024), "2M"},
+		{"Gigabytes", BytesCount(3 * 1024 * 1024 * 1024), "3G"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.input.String())
+		})
+	}
+}
+
+func TestBytesCount_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		input BytesCount
+		want  string
+	}{
+		{"Bytes", BytesCount(256), `"256B"`},
+		{"Kilobytes", BytesCount(1024), `"1K"`},
+		{"Megabytes", BytesCount(5 * 1024 * 1024), `"5M"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.input)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, string(data))
+		})
+	}
+}
+
+func TestBytesCount_MarshalYAML(t *testing.T) {
+	tests := []struct {
+		name  string
+		input BytesCount
+		want  string
+	}{
+		{"Bytes", BytesCount(128), "128B\n"},
+		{"Kilobytes", BytesCount(1024), "1K\n"},
+		{"Megabytes", BytesCount(7 * 1024 * 1024), "7M\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := yaml.Marshal(tt.input)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, string(data))
+		})
+	}
+}
+
+func TestBytesCount_MarshalText(t *testing.T) {
+	tests := []struct {
+		name  string
+		input BytesCount
+		want  string
+	}{
+		{"Bytes", BytesCount(256), "256B"},
+		{"Kilobytes", BytesCount(1024), "1K"},
+		{"Megabytes", BytesCount(5 * 1024 * 1024), "5M"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := tt.input.MarshalText()
+			require.NoError(t, err)
+			require.Equal(t, tt.want, string(data))
+		})
+	}
+}
+
+func TestTimeDuration_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    TimeDuration
+		wantErr bool
+	}{
+		{"Valid Integer", `1000`, TimeDuration(time.Second), false},
+		{"Valid Human-Readable", `"1s"`, TimeDuration(time.Second), false},
+		{"Invalid Format", `"invalid"`, 0, true},
+		{"Negative Value", `"-1000"`, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var d TimeDuration
+			err := json.Unmarshal([]byte(tt.input), &d)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, d)
+			}
+		})
+	}
+}
+
+func TestTimeDuration_UnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    TimeDuration
+		wantErr bool
+	}{
+		{"Valid Integer", "duration: 2000", TimeDuration(2 * time.Second), false},
+		{"Valid Human-Readable", "duration: 2s", TimeDuration(2 * time.Second), false},
+		{"Invalid Format", "duration: invalid", 0, true},
+		{"Negative Value", "duration: -2000", 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg struct{ Duration TimeDuration }
+			err := yaml.Unmarshal([]byte(tt.input), &cfg)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, cfg.Duration)
+			}
+		})
+	}
+}
+
+func TestTimeDuration_String(t *testing.T) {
+	tests := []struct {
+		name  string
+		input TimeDuration
+		want  string
+	}{
+		{"Milliseconds", TimeDuration(500 * time.Millisecond), "500ms"},
+		{"Seconds", TimeDuration(time.Second), "1s"},
+		{"Minutes", TimeDuration(time.Minute), "1m0s"},
+		{"Hours", TimeDuration(time.Hour), "1h0m0s"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.input.String())
+		})
+	}
+}
+
+func TestTimeDuration_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		input TimeDuration
+		want  string
+	}{
+		{"Milliseconds", TimeDuration(250 * time.Millisecond), `"250ms"`},
+		{"Seconds", TimeDuration(time.Second), `"1s"`},
+		{"Minutes", TimeDuration(3 * time.Minute), `"3m0s"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.input)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, string(data))
+		})
+	}
+}
+
+func TestTimeDuration_MarshalYAML(t *testing.T) {
+	tests := []struct {
+		name  string
+		input TimeDuration
+		want  string
+	}{
+		{"Milliseconds", TimeDuration(150 * time.Millisecond), "150ms\n"},
+		{"Seconds", TimeDuration(time.Second), "1s\n"},
+		{"Minutes", TimeDuration(5 * time.Minute), "5m0s\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := yaml.Marshal(tt.input)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, string(data))
+		})
+	}
+}
+
+func TestTimeDuration_MarshalText(t *testing.T) {
+	tests := []struct {
+		name  string
+		input TimeDuration
+		want  string
+	}{
+		{"Milliseconds", TimeDuration(150 * time.Millisecond), "150ms"},
+		{"Seconds", TimeDuration(time.Second), "1s"},
+		{"Minutes", TimeDuration(5 * time.Minute), "5m0s"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := tt.input.MarshalText()
+			require.NoError(t, err)
+			require.Equal(t, tt.want, string(data))
+		})
+	}
+}

--- a/config/custom_types_test.go
+++ b/config/custom_types_test.go
@@ -15,21 +15,23 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func TestBytesCount_UnmarshalJSON(t *testing.T) {
+func TestByteSize_UnmarshalJSON(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   string
-		want    BytesCount
+		want    ByteSize
 		wantErr bool
 	}{
-		{"Valid Integer", `1024`, BytesCount(1024), false},
-		{"Valid Human-Readable", `"10MB"`, BytesCount(10 * 1024 * 1024), false},
+		{"Valid Integer", `1024`, ByteSize(1024), false},
+		{"Valid Human-Readable, MB", `"10MB"`, ByteSize(10 * 1024 * 1024), false},
+		{"Valid Human-Readable, MiB", `"10MiB"`, ByteSize(10 * 1024 * 1024), false},
+		{"Valid Human-Readable, k8s format, Mi", `"10Mi"`, ByteSize(10 * 1024 * 1024), false},
 		{"Invalid Format", `"invalid"`, 0, true},
 		{"Negative Value", `"-1024"`, 0, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var b BytesCount
+			var b ByteSize
 			err := json.Unmarshal([]byte(tt.input), &b)
 			if tt.wantErr {
 				require.Error(t, err)
@@ -41,21 +43,23 @@ func TestBytesCount_UnmarshalJSON(t *testing.T) {
 	}
 }
 
-func TestBytesCount_UnmarshalYAML(t *testing.T) {
+func TestByteSize_UnmarshalYAML(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   string
-		want    BytesCount
+		want    ByteSize
 		wantErr bool
 	}{
-		{"Valid Integer", "size: 2048", BytesCount(2048), false},
-		{"Valid Human-Readable", "size: 20MB", BytesCount(20 * 1024 * 1024), false},
+		{"Valid Integer", "size: 2048", ByteSize(2048), false},
+		{"Valid Human-Readable, MB", "size: 20MB", ByteSize(20 * 1024 * 1024), false},
+		{"Valid Human-Readable, MiB", "size: 20MiB", ByteSize(20 * 1024 * 1024), false},
+		{"Valid Human-Readable, k8s format, Mi", "size: 20Mi", ByteSize(20 * 1024 * 1024), false},
 		{"Invalid Format", "size: invalid", 0, true},
 		{"Negative Value", "size: -1024", 0, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var cfg struct{ Size BytesCount }
+			var cfg struct{ Size ByteSize }
 			err := yaml.Unmarshal([]byte(tt.input), &cfg)
 			if tt.wantErr {
 				require.Error(t, err)
@@ -67,21 +71,23 @@ func TestBytesCount_UnmarshalYAML(t *testing.T) {
 	}
 }
 
-func TestBytesCount_UnmarshalText(t *testing.T) {
+func TestByteSize_UnmarshalText(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   string
-		want    BytesCount
+		want    ByteSize
 		wantErr bool
 	}{
-		{"Valid Integer", "4096", BytesCount(4096), false},
-		{"Valid Human-Readable", "20MB", BytesCount(20 * 1024 * 1024), false},
+		{"Valid Integer", "4096", ByteSize(4096), false},
+		{"Valid Human-Readable, MB", `"10MB"`, ByteSize(10 * 1024 * 1024), false},
+		{"Valid Human-Readable, MiB", `"10MiB"`, ByteSize(10 * 1024 * 1024), false},
+		{"Valid Human-Readable, k8s format, Mi", `"10Mi"`, ByteSize(10 * 1024 * 1024), false},
 		{"Invalid Format", "invalid", 0, true},
 		{"Negative Value", "-1024", 0, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var b BytesCount
+			var b ByteSize
 			err := b.UnmarshalText([]byte(tt.input))
 			if tt.wantErr {
 				require.Error(t, err)
@@ -93,16 +99,16 @@ func TestBytesCount_UnmarshalText(t *testing.T) {
 	}
 }
 
-func TestBytesCount_String(t *testing.T) {
+func TestByteSize_String(t *testing.T) {
 	tests := []struct {
 		name  string
-		input BytesCount
+		input ByteSize
 		want  string
 	}{
-		{"Bytes", BytesCount(512), "512B"},
-		{"Kilobytes", BytesCount(1024), "1K"},
-		{"Megabytes", BytesCount(2 * 1024 * 1024), "2M"},
-		{"Gigabytes", BytesCount(3 * 1024 * 1024 * 1024), "3G"},
+		{"Bytes", ByteSize(512), "512B"},
+		{"Kilobytes", ByteSize(1024), "1K"},
+		{"Megabytes", ByteSize(2 * 1024 * 1024), "2M"},
+		{"Gigabytes", ByteSize(3 * 1024 * 1024 * 1024), "3G"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -111,15 +117,15 @@ func TestBytesCount_String(t *testing.T) {
 	}
 }
 
-func TestBytesCount_MarshalJSON(t *testing.T) {
+func TestByteSize_MarshalJSON(t *testing.T) {
 	tests := []struct {
 		name  string
-		input BytesCount
+		input ByteSize
 		want  string
 	}{
-		{"Bytes", BytesCount(256), `"256B"`},
-		{"Kilobytes", BytesCount(1024), `"1K"`},
-		{"Megabytes", BytesCount(5 * 1024 * 1024), `"5M"`},
+		{"Bytes", ByteSize(256), `"256B"`},
+		{"Kilobytes", ByteSize(1024), `"1K"`},
+		{"Megabytes", ByteSize(5 * 1024 * 1024), `"5M"`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -130,15 +136,15 @@ func TestBytesCount_MarshalJSON(t *testing.T) {
 	}
 }
 
-func TestBytesCount_MarshalYAML(t *testing.T) {
+func TestByteSize_MarshalYAML(t *testing.T) {
 	tests := []struct {
 		name  string
-		input BytesCount
+		input ByteSize
 		want  string
 	}{
-		{"Bytes", BytesCount(128), "128B\n"},
-		{"Kilobytes", BytesCount(1024), "1K\n"},
-		{"Megabytes", BytesCount(7 * 1024 * 1024), "7M\n"},
+		{"Bytes", ByteSize(128), "128B\n"},
+		{"Kilobytes", ByteSize(1024), "1K\n"},
+		{"Megabytes", ByteSize(7 * 1024 * 1024), "7M\n"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -149,15 +155,15 @@ func TestBytesCount_MarshalYAML(t *testing.T) {
 	}
 }
 
-func TestBytesCount_MarshalText(t *testing.T) {
+func TestByteSize_MarshalText(t *testing.T) {
 	tests := []struct {
 		name  string
-		input BytesCount
+		input ByteSize
 		want  string
 	}{
-		{"Bytes", BytesCount(256), "256B"},
-		{"Kilobytes", BytesCount(1024), "1K"},
-		{"Megabytes", BytesCount(5 * 1024 * 1024), "5M"},
+		{"Bytes", ByteSize(256), "256B"},
+		{"Kilobytes", ByteSize(1024), "1K"},
+		{"Megabytes", ByteSize(5 * 1024 * 1024), "5M"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -175,7 +181,7 @@ func TestTimeDuration_UnmarshalJSON(t *testing.T) {
 		want    TimeDuration
 		wantErr bool
 	}{
-		{"Valid Integer", `1000`, TimeDuration(time.Second), false},
+		{"Valid Integer", `1000000000`, TimeDuration(time.Second), false},
 		{"Valid Human-Readable", `"1s"`, TimeDuration(time.Second), false},
 		{"Invalid Format", `"invalid"`, 0, true},
 		{"Negative Value", `"-1000"`, 0, true},
@@ -201,7 +207,7 @@ func TestTimeDuration_UnmarshalYAML(t *testing.T) {
 		want    TimeDuration
 		wantErr bool
 	}{
-		{"Valid Integer", "duration: 2000", TimeDuration(2 * time.Second), false},
+		{"Valid Integer", "duration: 2000000000", TimeDuration(2 * time.Second), false},
 		{"Valid Human-Readable", "duration: 2s", TimeDuration(2 * time.Second), false},
 		{"Invalid Format", "duration: invalid", 0, true},
 		{"Negative Value", "duration: -2000", 0, true},

--- a/config/data_provider.go
+++ b/config/data_provider.go
@@ -50,6 +50,8 @@ type DataProvider interface {
 	GetDuration(key string) (time.Duration, error)
 	GetSizeInBytes(key string) (uint64, error)
 	GetStringMapString(key string) (map[string]string, error)
+	GetBytesCount(key string) (BytesCount, error)
+
 	Unmarshal(rawVal interface{}, opts ...DecoderConfigOption) error
 	UnmarshalKey(key string, rawVal interface{}, opts ...DecoderConfigOption) error
 

--- a/config/data_provider.go
+++ b/config/data_provider.go
@@ -48,9 +48,8 @@ type DataProvider interface {
 	GetStringFromSet(key string, set []string, ignoreCase bool) (string, error)
 	GetStringSlice(key string) ([]string, error)
 	GetDuration(key string) (time.Duration, error)
-	GetSizeInBytes(key string) (uint64, error)
+	GetSizeInBytes(key string) (ByteSize, error)
 	GetStringMapString(key string) (map[string]string, error)
-	GetBytesCount(key string) (BytesCount, error)
 
 	Unmarshal(rawVal interface{}, opts ...DecoderConfigOption) error
 	UnmarshalKey(key string, rawVal interface{}, opts ...DecoderConfigOption) error

--- a/config/example_test.go
+++ b/config/example_test.go
@@ -50,7 +50,7 @@ type logConfig struct {
 	File  struct {
 		Path     string
 		Rotation struct {
-			MaxSize    uint64
+			MaxSize    ByteSize
 			MaxBackups int
 			Compress   bool
 		}

--- a/config/key_prefixed_data_provider.go
+++ b/config/key_prefixed_data_provider.go
@@ -105,7 +105,7 @@ func (kp *KeyPrefixedDataProvider) GetStringSlice(key string) (res []string, err
 }
 
 // GetSizeInBytes tries to retrieve the value associated with the key as a size in bytes.
-func (kp *KeyPrefixedDataProvider) GetSizeInBytes(key string) (uint64, error) {
+func (kp *KeyPrefixedDataProvider) GetSizeInBytes(key string) (ByteSize, error) {
 	return kp.delegate.GetSizeInBytes(kp.makeKey(key))
 }
 
@@ -122,11 +122,6 @@ func (kp *KeyPrefixedDataProvider) GetDuration(key string) (res time.Duration, e
 // GetStringMapString tries to retrieve the value associated with the key as an map where key and value are strings.
 func (kp *KeyPrefixedDataProvider) GetStringMapString(key string) (res map[string]string, err error) {
 	return kp.delegate.GetStringMapString(kp.makeKey(key))
-}
-
-// GetBytesCount tries to retrieve the value associated with the key as a size in bytes.
-func (kp *KeyPrefixedDataProvider) GetBytesCount(key string) (BytesCount, error) {
-	return kp.delegate.GetBytesCount(kp.makeKey(key))
 }
 
 // Unmarshal unmarshals the config into a Struct.

--- a/config/key_prefixed_data_provider.go
+++ b/config/key_prefixed_data_provider.go
@@ -124,6 +124,11 @@ func (kp *KeyPrefixedDataProvider) GetStringMapString(key string) (res map[strin
 	return kp.delegate.GetStringMapString(kp.makeKey(key))
 }
 
+// GetBytesCount tries to retrieve the value associated with the key as a size in bytes.
+func (kp *KeyPrefixedDataProvider) GetBytesCount(key string) (BytesCount, error) {
+	return kp.delegate.GetBytesCount(kp.makeKey(key))
+}
+
 // Unmarshal unmarshals the config into a Struct.
 func (kp *KeyPrefixedDataProvider) Unmarshal(rawVal interface{}, opts ...DecoderConfigOption) (err error) {
 	return kp.delegate.UnmarshalKey(kp.makeKey(""), rawVal, opts...)

--- a/config/viper_adapter.go
+++ b/config/viper_adapter.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"code.cloudfoundry.org/bytefmt"
 	"github.com/spf13/cast"
 	"github.com/spf13/viper"
 )
@@ -132,26 +131,31 @@ func (va *ViperAdapter) GetStringSlice(key string) (res []string, err error) {
 }
 
 // GetSizeInBytes tries to retrieve the value associated with the key as a size in bytes.
-func (va *ViperAdapter) GetSizeInBytes(key string) (uint64, error) {
-	sizeStr, err := va.GetString(key)
-	if err != nil {
-		return 0, WrapKeyErrIfNeeded(key, err)
-	}
-	if sizeStr == "" {
+func (va *ViperAdapter) GetSizeInBytes(key string) (ByteSize, error) {
+	val := va.Get(key)
+	if val == nil {
 		return 0, nil
 	}
-	// Handle k8s power-of-two values.
-	for _, k8sByteSuffix := range [...]string{"Ki", "Mi", "Gi", "Ti", "Pi", "Ei"} {
-		if strings.HasSuffix(sizeStr, k8sByteSuffix) {
-			sizeStr = sizeStr[:len(sizeStr)-1]
-			break
+	switch v := val.(type) {
+	case string:
+		return parseByteSizeFromString(v)
+
+	case int, int8, int16, int32, int64: // Handle all signed integers
+		num := cast.ToInt64(val)
+		if num < 0 {
+			return 0, fmt.Errorf("negative value is not allowed (%d)", num)
 		}
+		return ByteSize(num), nil
+
+	case uint, uint8, uint16, uint32, uint64: // Handle all unsigned integers
+		return ByteSize(cast.ToUint64(val)), nil
+
+	case ByteSize:
+		return v, nil
+
+	default:
+		return 0, fmt.Errorf("unsupported type for ByteSize (%T)", val)
 	}
-	res, err := bytefmt.ToBytes(sizeStr)
-	if err != nil {
-		return 0, WrapKeyErrIfNeeded(key, err)
-	}
-	return res, nil
 }
 
 // GetStringFromSet tries to retrieve the value associated with the key as a string from the specified set.
@@ -174,7 +178,7 @@ func (va *ViperAdapter) GetDuration(key string) (res time.Duration, err error) {
 	if val == nil {
 		return
 	}
-	res, err = cast.ToDurationE(va.Get(key))
+	res, err = cast.ToDurationE(val)
 	err = WrapKeyErrIfNeeded(key, err)
 	return
 }
@@ -189,41 +193,6 @@ func (va *ViperAdapter) GetStringMapString(key string) (res map[string]string, e
 	res, err = cast.ToStringMapStringE(val)
 	err = WrapKeyErrIfNeeded(key, err)
 	return
-}
-
-// GetBytesCount tries to retrieve the value associated with the key as a size in bytes.
-func (va *ViperAdapter) GetBytesCount(key string) (BytesCount, error) {
-	val := va.Get(key)
-	if val == nil {
-		return 0, nil
-	}
-	switch v := val.(type) {
-	case string:
-		num, err := bytefmt.ToBytes(v)
-		if err != nil {
-			return 0, fmt.Errorf("invalid bytes format: %s", v)
-		}
-		return BytesCount(num), nil
-
-	case int, int8, int16, int32, int64: // Handle all signed integers
-		num := cast.ToInt64(val)
-		if num < 0 {
-			return 0, fmt.Errorf("negative value is not allowed: %d", num)
-		}
-		return BytesCount(num), nil
-
-	case uint, uint8, uint16, uint32, uint64: // Handle all unsigned integers
-		return BytesCount(cast.ToUint64(val)), nil
-
-	case float32, float64: // Handle floating-point values (converting them to uint64)
-		return BytesCount(uint64(cast.ToFloat64(val))), nil
-
-	case BytesCount:
-		return v, nil
-
-	default:
-		return 0, fmt.Errorf("unsupported type for BytesCount: %T", val)
-	}
 }
 
 // Unmarshal unmarshals the config into a Struct.

--- a/config/viper_adapter_test.go
+++ b/config/viper_adapter_test.go
@@ -185,7 +185,7 @@ func TestViperAdapter_GetSizeInBytes(t *testing.T) {
 	const key = "sizeinbytes.key"
 
 	t.Run("attempt to get invalid size in bytes", func(t *testing.T) {
-		invalidVals := []interface{}{10, true, "not bytes", []string{"foo", "bar"}, "1s", "1h"}
+		invalidVals := []interface{}{true, "not bytes", []string{"foo", "bar"}, "1s", "1h"}
 		for _, invVal := range invalidVals {
 			viperAdapter.Set(key, invVal)
 			_, err := viperAdapter.GetSizeInBytes(key)
@@ -194,11 +194,12 @@ func TestViperAdapter_GetSizeInBytes(t *testing.T) {
 	})
 
 	t.Run("get size in bytes", func(t *testing.T) {
-		testData := map[string]uint64{
-			"1K":  1024,
-			"2M":  1024 * 1024 * 2,
-			"3G":  1024 * 1024 * 1024 * 3,
-			"4Gi": 1024 * 1024 * 1024 * 4, // k8s format.
+		testData := map[string]ByteSize{
+			"1K":   1024,
+			"2M":   1024 * 1024 * 2,
+			"3G":   1024 * 1024 * 1024 * 3,
+			"4Gi":  1024 * 1024 * 1024 * 4, // k8s format.
+			"5Kib": 1024 * 5,
 		}
 		for val, want := range testData {
 			viperAdapter.Set(key, val)

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	go.uber.org/atomic v1.11.0
 	golang.org/x/time v0.6.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -48,5 +49,4 @@ require (
 	golang.org/x/text v0.17.0 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/httpclient/config_test.go
+++ b/httpclient/config_test.go
@@ -8,176 +8,295 @@ package httpclient
 
 import (
 	"bytes"
-	"strings"
+	"encoding/json"
 	"testing"
 	"time"
 
+	"github.com/mitchellh/mapstructure"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	"github.com/acronis/go-appkit/config"
-	"github.com/acronis/go-appkit/retry"
 )
 
-func TestConfigWithLoader(t *testing.T) {
-	yamlData := testYamlData(nil)
-	actualConfig := &Config{}
-	err := config.NewDefaultLoader("").LoadFromReader(bytes.NewReader(yamlData), config.DataTypeYAML, actualConfig)
-	require.NoError(t, err, "load configuration")
+type AppConfig struct {
+	HTTPClient *Config `mapstructure:"httpClient" json:"httpClient" yaml:"httpClient"`
+}
 
-	expectedConfig := &Config{
-		Retries: RetriesConfig{
-			Enabled:     true,
-			MaxAttempts: 30,
-			Policy:      RetryPolicyExponential,
-			ExponentialBackoff: ExponentialBackoffConfig{
-				InitialInterval: 3 * time.Second,
-				Multiplier:      2,
-			},
+func TestConfig(t *testing.T) {
+	expectedAppCfg := AppConfig{HTTPClient: NewDefaultConfig(WithKeyPrefix("httpClient"))}
+	expectedAppCfg.HTTPClient.Retries = RetriesConfig{
+		Enabled:     true,
+		MaxAttempts: 30,
+		Policy:      RetryPolicyExponential,
+		ExponentialBackoff: ExponentialBackoffConfig{
+			InitialInterval: config.TimeDuration(3 * time.Second),
+			Multiplier:      2,
 		},
-		RateLimits: RateLimitsConfig{
-			Enabled:     true,
-			Limit:       300,
-			Burst:       3000,
-			WaitTimeout: 3 * time.Second,
-		},
-		Log: LogConfig{
-			Enabled:              true,
-			SlowRequestThreshold: 5 * time.Second,
-			Mode:                 "all",
-		},
-		Metrics: MetricsConfig{Enabled: true},
-		Timeout: 30 * time.Second,
 	}
-
-	require.Equal(t, expectedConfig, actualConfig, "configuration does not match expected")
-}
-
-func TestConfigRateLimit(t *testing.T) {
-	yamlData := testYamlData([][]string{{"limit: 300", "limit: -300"}})
-	actualConfig := &Config{}
-	err := config.NewDefaultLoader("").LoadFromReader(bytes.NewReader(yamlData), config.DataTypeYAML, actualConfig)
-	require.Error(t, err)
-	require.Equal(t, "rateLimits.limit: must be positive", err.Error())
-
-	yamlData = testYamlData([][]string{{"burst: 3000", "burst: -3"}})
-	actualConfig = &Config{}
-	err = config.NewDefaultLoader("").LoadFromReader(bytes.NewReader(yamlData), config.DataTypeYAML, actualConfig)
-	require.Error(t, err)
-	require.Equal(t, "rateLimits.burst: must be positive", err.Error())
-
-	yamlData = testYamlData([][]string{{"waitTimeout: 3s", "waitTimeout: -3s"}})
-	actualConfig = &Config{}
-	err = config.NewDefaultLoader("").LoadFromReader(bytes.NewReader(yamlData), config.DataTypeYAML, actualConfig)
-	require.Error(t, err)
-	require.Equal(t, "rateLimits.waitTimeout: must be positive", err.Error())
-}
-
-func TestConfigRetries(t *testing.T) {
-	yamlData := testYamlData([][]string{{"maxAttempts: 30", "maxAttempts: -30"}})
-	actualConfig := &Config{}
-	err := config.NewDefaultLoader("").LoadFromReader(bytes.NewReader(yamlData), config.DataTypeYAML, actualConfig)
-	require.Error(t, err)
-	require.Equal(t, "retries.maxAttempts: must be positive", err.Error())
-}
-
-func TestConfigLogger(t *testing.T) {
-	yamlData := testYamlData([][]string{{"slowRequestThreshold: 5s", "slowRequestThreshold: -5s"}})
-	actualConfig := &Config{}
-	err := config.NewDefaultLoader("").LoadFromReader(bytes.NewReader(yamlData), config.DataTypeYAML, actualConfig)
-	require.Error(t, err)
-	require.Equal(t, "log.slowRequestThreshold: can not be negative", err.Error())
-
-	yamlData = testYamlData([][]string{{"mode: all", "mode: invalid"}})
-	actualConfig = &Config{}
-	err = config.NewDefaultLoader("").LoadFromReader(bytes.NewReader(yamlData), config.DataTypeYAML, actualConfig)
-	require.Error(t, err)
-	require.Equal(t, "log.mode: choose one of: [all, failed]", err.Error())
-}
-
-func TestConfigRetriesPolicy(t *testing.T) {
-	yamlData := testYamlData([][]string{{"policy: exponential", "policy: invalid"}})
-	actualConfig := &Config{}
-	err := config.NewDefaultLoader("").LoadFromReader(bytes.NewReader(yamlData), config.DataTypeYAML, actualConfig)
-	require.Error(t, err)
-	require.Equal(t, "retries.policy: must be one of: [exponential, constant]", err.Error())
-
-	yamlData = testYamlData([][]string{
-		{"initialInterval: 3s", "initialInterval: -1s"},
-	})
-	err = config.NewDefaultLoader("").LoadFromReader(bytes.NewReader(yamlData), config.DataTypeYAML, actualConfig)
-	require.Error(t, err)
-	require.Equal(t, "retries.exponentialBackoff.initialInterval: must be positive", err.Error())
-
-	yamlData = testYamlData([][]string{{"multiplier: 2", "multiplier: 1"}})
-	err = config.NewDefaultLoader("").LoadFromReader(bytes.NewReader(yamlData), config.DataTypeYAML, actualConfig)
-	require.Error(t, err)
-	require.Equal(t, "retries.exponentialBackoff.multiplier: must be greater than 1", err.Error())
-
-	yamlData = testYamlData([][]string{
-		{"policy: exponential", "policy: constant"},
-		{"interval: 2s", "interval: -3s"},
-	})
-	err = config.NewDefaultLoader("").LoadFromReader(bytes.NewReader(yamlData), config.DataTypeYAML, actualConfig)
-	require.Error(t, err)
-	require.Equal(t, "retries.constantBackoff.interval: must be positive", err.Error())
-
-	yamlData = testYamlData([][]string{
-		{"policy: exponential", "policy:"},
-	})
-	err = config.NewDefaultLoader("").LoadFromReader(bytes.NewReader(yamlData), config.DataTypeYAML, actualConfig)
-	require.NoError(t, err)
-	require.Nil(t, actualConfig.Retries.GetPolicy())
-
-	yamlData = testYamlData(nil)
-	err = config.NewDefaultLoader("").LoadFromReader(bytes.NewReader(yamlData), config.DataTypeYAML, actualConfig)
-	require.NoError(t, err)
-	require.Implements(t, (*retry.Policy)(nil), actualConfig.Retries.GetPolicy())
-}
-
-func TestConfigDisableWithLoader(t *testing.T) {
-	yamlData := []byte(`
-retries:
-  enabled: false
-rateLimits:
-  enabled: false
-logger:
-  enabled: false
-metrics:
-  enabled: false
-timeout: 30s
-`)
-	actualConfig := &Config{}
-	err := config.NewDefaultLoader("").LoadFromReader(bytes.NewReader(yamlData), config.DataTypeYAML, actualConfig)
-	require.NoError(t, err)
-}
-
-func testYamlData(replacements [][]string) []byte {
-	yamlData := `
-retries:
-  enabled: true
-  maxAttempts: 30
-  policy: exponential
-  exponentialBackoff:
-    initialInterval: 3s
-    multiplier: 2
-  constantBackoff:
-    interval: 2s
-rateLimits:
-  enabled: true
-  limit: 300
-  burst: 3000
-  waitTimeout: 3s
-log:
-  enabled: true
-  slowRequestThreshold: 5s
-  mode: all
-metrics:
-  enabled: true
-timeout: 30s
-`
-	for i := range replacements {
-		yamlData = strings.Replace(yamlData, replacements[i][0], replacements[i][1], 1)
+	expectedAppCfg.HTTPClient.RateLimits = RateLimitsConfig{
+		Enabled:     true,
+		Limit:       300,
+		Burst:       3000,
+		WaitTimeout: config.TimeDuration(3 * time.Second),
 	}
+	expectedAppCfg.HTTPClient.Log = LogConfig{
+		Enabled:              true,
+		SlowRequestThreshold: config.TimeDuration(5 * time.Second),
+		Mode:                 "all",
+	}
+	expectedAppCfg.HTTPClient.Metrics = MetricsConfig{Enabled: true}
+	expectedAppCfg.HTTPClient.Timeout = config.TimeDuration(30 * time.Second)
 
-	return []byte(yamlData)
+	tests := []struct {
+		name        string
+		cfgDataType config.DataType
+		cfgData     string
+	}{
+		{
+			name:        "yaml config",
+			cfgDataType: config.DataTypeYAML,
+			cfgData: `
+httpClient:
+  retries:
+    enabled: true
+    maxAttempts: 30
+    policy: exponential
+    exponentialBackoff:
+      initialInterval: 3s
+      multiplier: 2
+  rateLimits:
+    enabled: true
+    limit: 300
+    burst: 3000
+    waitTimeout: 3s
+  log:
+    enabled: true
+    slowRequestThreshold: 5s
+    mode: all
+  metrics:
+    enabled: true
+  timeout: 30s
+`,
+		},
+		{
+			name:        "json config",
+			cfgDataType: config.DataTypeJSON,
+			cfgData: `
+{
+	"httpClient": {
+		"retries": {
+			"enabled": true,
+			"maxAttempts": 30,
+			"policy": "exponential",
+			"exponentialBackoff": {
+				"initialInterval": "3s",
+				"multiplier": 2
+			}
+		},
+		"rateLimits": {
+			"enabled": true,
+			"limit": 300,
+			"burst": 3000,
+			"waitTimeout": "3s"
+		},
+		"log": {
+			"enabled": true,
+			"slowRequestThreshold": "5s",
+			"mode": "all"
+		},
+		"metrics": {
+			"enabled": true
+		},
+		"timeout": "30s"
+	}
+}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var appCfg AppConfig
+
+			// Load config using config.Loader.
+			appCfg = AppConfig{HTTPClient: NewDefaultConfig(WithKeyPrefix("httpClient"))}
+			cfgLoader := config.NewLoader(config.NewViperAdapter())
+			err := cfgLoader.LoadFromReader(bytes.NewBuffer([]byte(tt.cfgData)), tt.cfgDataType, appCfg.HTTPClient)
+			require.NoError(t, err)
+			require.Equal(t, expectedAppCfg, appCfg)
+
+			// Load config using viper unmarshal.
+			appCfg = AppConfig{HTTPClient: NewDefaultConfig(WithKeyPrefix("httpClient"))}
+			vpr := viper.New()
+			vpr.SetConfigType(string(tt.cfgDataType))
+			require.NoError(t, vpr.ReadConfig(bytes.NewBuffer([]byte(tt.cfgData))))
+			require.NoError(t, vpr.Unmarshal(&appCfg, func(c *mapstructure.DecoderConfig) {
+				c.DecodeHook = mapstructure.TextUnmarshallerHookFunc()
+			}))
+			require.Equal(t, expectedAppCfg, appCfg)
+
+			// Load config using yaml/json unmarshal.
+			appCfg = AppConfig{HTTPClient: NewDefaultConfig(WithKeyPrefix("httpClient"))}
+			switch tt.cfgDataType {
+			case config.DataTypeYAML:
+				require.NoError(t, yaml.Unmarshal([]byte(tt.cfgData), &appCfg))
+				require.Equal(t, expectedAppCfg, appCfg)
+			case config.DataTypeJSON:
+				require.NoError(t, json.Unmarshal([]byte(tt.cfgData), &appCfg))
+				require.Equal(t, expectedAppCfg, appCfg)
+			default:
+				t.Fatalf("unsupported config data type: %s", tt.cfgDataType)
+			}
+		})
+	}
+}
+
+func TestNewDefaultConfig(t *testing.T) {
+	var cfg *Config
+
+	// Empty config, all defaults for the data provider should be used
+	cfg = NewConfig()
+	require.NoError(t, config.NewDefaultLoader("").LoadFromReader(bytes.NewBuffer(nil), config.DataTypeYAML, cfg))
+	require.Equal(t, NewDefaultConfig(), cfg)
+
+	// viper.Unmarshal
+	cfg = NewDefaultConfig()
+	vpr := viper.New()
+	vpr.SetConfigType("yaml")
+	require.NoError(t, vpr.Unmarshal(&cfg))
+	require.Equal(t, NewDefaultConfig(), cfg)
+
+	// yaml.Unmarshal
+	cfg = NewDefaultConfig()
+	require.NoError(t, yaml.Unmarshal([]byte(""), &cfg))
+	require.Equal(t, NewDefaultConfig(), cfg)
+
+	// json.Unmarshal
+	cfg = NewDefaultConfig()
+	require.NoError(t, json.Unmarshal([]byte("{}"), &cfg))
+	require.Equal(t, NewDefaultConfig(), cfg)
+}
+
+func TestConfigValidationErrors(t *testing.T) {
+	tests := []struct {
+		name           string
+		yamlData       string
+		expectedErrMsg string
+	}{
+		{
+			name: "error, retries maxAttempts must be positive",
+			yamlData: `
+httpClient:
+  retries:
+    enabled: true
+    maxAttempts: -1
+`,
+			expectedErrMsg: `httpClient.retries.maxAttempts: must be positive`,
+		},
+		{
+			name: "error, rateLimits limit must be positive",
+			yamlData: `
+httpClient:
+  rateLimits:
+    enabled: true
+    limit: -1
+`,
+			expectedErrMsg: `httpClient.rateLimits.limit: must be positive`,
+		},
+		{
+			name: "error, rateLimits burst must be positive",
+			yamlData: `
+httpClient:
+  rateLimits:
+    enabled: true
+    limit: 10
+    burst: -1
+`,
+			expectedErrMsg: `httpClient.rateLimits.burst: must be positive`,
+		},
+		{
+			name: "error, rateLimits waitTimeout must be positive",
+			yamlData: `
+httpClient:
+  rateLimits:
+    enabled: true
+    limit: 10
+    waitTimeout: -1s
+`,
+			expectedErrMsg: `httpClient.rateLimits.waitTimeout: must be positive`,
+		},
+		{
+			name: "error, log slowRequestThreshold can not be negative",
+			yamlData: `
+httpClient:
+  log:
+    enabled: true
+    slowRequestThreshold: -1s
+`,
+			expectedErrMsg: `httpClient.log.slowRequestThreshold: can not be negative`,
+		},
+		{
+			name: "error, unknown log mode",
+			yamlData: `
+httpClient:
+  log:
+    enabled: true
+    mode: invalid-mode
+`,
+			expectedErrMsg: `httpClient.log.mode: choose one of: [all, failed]`,
+		},
+		{
+			name: "error, unknown retries policy",
+			yamlData: `
+httpClient:
+  retries:
+    enabled: true
+    policy: invalid-policy
+`,
+			expectedErrMsg: `httpClient.retries.policy: must be one of: [exponential, constant]`,
+		},
+		{
+			name: "error, exponentialBackoff initialInterval must be positive",
+			yamlData: `
+httpClient:
+  retries:
+    enabled: true
+    policy: exponential
+    exponentialBackoff:
+      initialInterval: -1s
+`,
+			expectedErrMsg: `httpClient.retries.exponentialBackoff.initialInterval: must be positive`,
+		},
+		{
+			name: "error, exponentialBackoff multiplier must be greater than 1",
+			yamlData: `
+httpClient:
+  retries:
+    enabled: true
+    policy: exponential
+    exponentialBackoff:
+      multiplier: 1
+`,
+			expectedErrMsg: `httpClient.retries.exponentialBackoff.multiplier: must be greater than 1`,
+		},
+		{
+			name: "error, constantBackoff interval must be positive",
+			yamlData: `
+httpClient:
+  retries:
+    enabled: true
+    policy: constant
+    constantBackoff:
+      interval: -1s
+`,
+			expectedErrMsg: `httpClient.retries.constantBackoff.interval: must be positive`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := NewConfig(WithKeyPrefix("httpClient"))
+			err := config.NewDefaultLoader("").LoadFromReader(bytes.NewBuffer([]byte(tt.yamlData)), config.DataTypeYAML, cfg)
+			require.EqualError(t, err, tt.expectedErrMsg)
+		})
+	}
 }

--- a/httpclient/httpclient.go
+++ b/httpclient/httpclient.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/acronis/go-appkit/log"
 )
@@ -111,7 +112,7 @@ func NewWithOpts(cfg *Config, opts Opts) (*http.Client, error) {
 		delegate = NewLoggingRoundTripperWithOpts(delegate, logOpts)
 	}
 
-	return &http.Client{Transport: delegate, Timeout: cfg.Timeout}, nil
+	return &http.Client{Transport: delegate, Timeout: time.Duration(cfg.Timeout)}, nil
 }
 
 // MustNewWithOpts wraps delegate transports with options

--- a/httpclient/httpclient_test.go
+++ b/httpclient/httpclient_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
+	"github.com/acronis/go-appkit/config"
 	"github.com/acronis/go-appkit/httpserver/middleware"
 	"github.com/acronis/go-appkit/log/logtest"
 	"github.com/acronis/go-appkit/testutil"
@@ -134,7 +135,7 @@ func TestMustHTTPClientWithOptsRoundTripperPolicy(t *testing.T) {
 	cfg.Retries.MaxAttempts = 1
 	cfg.Retries.Policy = RetryPolicyExponential
 	cfg.Retries.ExponentialBackoff = ExponentialBackoffConfig{
-		InitialInterval: 2 * time.Millisecond,
+		InitialInterval: config.TimeDuration(2 * time.Millisecond),
 		Multiplier:      1.1,
 	}
 

--- a/httpclient/retryable_round_tripper_test.go
+++ b/httpclient/retryable_round_tripper_test.go
@@ -424,8 +424,7 @@ func TestCheckErrorIsTemporary(t *testing.T) {
 			WantErr:       "EOF",
 		},
 	}
-	for i := range tests {
-		tt := tests[i]
+	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			req, err := http.NewRequest(tt.ReqMethod, tt.ReqURL, nil)
 			require.NoError(t, err)

--- a/httpserver/config.go
+++ b/httpserver/config.go
@@ -200,7 +200,7 @@ type LimitsConfig struct {
 	MaxRequests int `mapstructure:"maxRequests" yaml:"maxRequests" json:"maxRequests"`
 
 	// MaxBodySizeBytes is the maximum size of the request body in bytes.
-	MaxBodySizeBytes config.BytesCount `mapstructure:"maxBodySize" yaml:"maxBodySize" json:"maxBodySize"`
+	MaxBodySizeBytes config.ByteSize `mapstructure:"maxBodySize" yaml:"maxBodySize" json:"maxBodySize"`
 }
 
 // Set sets limit server configuration values from config.DataProvider.
@@ -214,7 +214,7 @@ func (l *LimitsConfig) Set(dp config.DataProvider) error {
 		return dp.WrapKeyErr(cfgKeyServerLimitsMaxRequests, fmt.Errorf("maxRequests must be positive"))
 	}
 
-	if l.MaxBodySizeBytes, err = dp.GetBytesCount(cfgKeyServerLimitsMaxBodySize); err != nil {
+	if l.MaxBodySizeBytes, err = dp.GetSizeInBytes(cfgKeyServerLimitsMaxBodySize); err != nil {
 		return dp.WrapKeyErr(cfgKeyServerLimitsMaxBodySize, err)
 	}
 

--- a/httpserver/config.go
+++ b/httpserver/config.go
@@ -7,79 +7,200 @@ Released under MIT license.
 package httpserver
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/acronis/go-appkit/config"
 )
 
+const cfgDefaultKeyPrefix = "server"
+
 const (
-	cfgKeyServerAddress                 = "server.address"
-	cfgKeyServerUnixSocketPath          = "server.unixSocketPath"
-	cfgKeyServerTLSCert                 = "server.tls.cert"
-	cfgKeyServerTLSKey                  = "server.tls.key"
-	cfgKeyServerTLSEnabled              = "server.tls.enabled"
-	cfgKeyServerTimeoutsWrite           = "server.timeouts.write"
-	cfgKeyServerTimeoutsRead            = "server.timeouts.read"
-	cfgKeyServerTimeoutsReadHeader      = "server.timeouts.readHeader"
-	cfgKeyServerTimeoutsIdle            = "server.timeouts.idle"
-	cfgKeyServerTimeoutsShutdown        = "server.timeouts.shutdown"
-	cfgKeyServerLimitsMaxRequests       = "server.limits.maxRequests"
-	cfgKeyServerLimitsMaxBodySize       = "server.limits.maxBodySize"
-	cfgKeyServerLogRequestStart         = "server.log.requestStart"
-	cfgKeyServerLogRequestHeaders       = "server.log.requestHeaders"
-	cfgKeyServerLogExcludedEndpoints    = "server.log.excludedEndpoints"
-	cfgKeyServerLogSecretQueryParams    = "server.log.secretQueryParams" // nolint:gosec // false positive
-	cfgKeyServerLogAddRequestInfo       = "server.log.addRequestInfo"
-	cfgKeyServerLogSlowRequestThreshold = "server.log.slowRequestThreshold"
+	cfgKeyServerAddress                 = "address"
+	cfgKeyServerUnixSocketPath          = "unixSocketPath"
+	cfgKeyServerTLSCert                 = "tls.cert"
+	cfgKeyServerTLSKey                  = "tls.key"
+	cfgKeyServerTLSEnabled              = "tls.enabled"
+	cfgKeyServerTimeoutsWrite           = "timeouts.write"
+	cfgKeyServerTimeoutsRead            = "timeouts.read"
+	cfgKeyServerTimeoutsReadHeader      = "timeouts.readHeader"
+	cfgKeyServerTimeoutsIdle            = "timeouts.idle"
+	cfgKeyServerTimeoutsShutdown        = "timeouts.shutdown"
+	cfgKeyServerLimitsMaxRequests       = "limits.maxRequests"
+	cfgKeyServerLimitsMaxBodySize       = "limits.maxBodySize"
+	cfgKeyServerLogRequestStart         = "log.requestStart"
+	cfgKeyServerLogRequestHeaders       = "log.requestHeaders"
+	cfgKeyServerLogExcludedEndpoints    = "log.excludedEndpoints"
+	cfgKeyServerLogSecretQueryParams    = "log.secretQueryParams" // nolint:gosec // false positive
+	cfgKeyServerLogAddRequestInfo       = "log.addRequestInfo"
+	cfgKeyServerLogSlowRequestThreshold = "log.slowRequestThreshold"
 )
 
 const (
 	defaultServerAddress            = ":8080"
-	defaultServerTimeoutsWrite      = "1m"
-	defaultServerTimeoutsRead       = "15s"
-	defaultServerTimeoutsReadHeader = "10s"
-	defaultServerTimeoutsIdle       = "1m"
-	defaultServerTimeoutsShutdown   = "5s"
+	defaultServerTimeoutsWrite      = time.Minute
+	defaultServerTimeoutsRead       = time.Second * 15
+	defaultServerTimeoutsReadHeader = time.Second * 10
+	defaultServerTimeoutsIdle       = time.Minute
+	defaultServerTimeoutsShutdown   = time.Second * 5
+	defaultSlowRequestThreshold     = time.Second
 	defaultServerLimitsMaxRequests  = 5000
-	defaultSlowRequestThreshold     = "1s"
 )
+
+// Config represents a set of configuration parameters for HTTPServer.
+// Configuration can be loaded in different formats (YAML, JSON) using config.Loader, viper,
+// or with json.Unmarshal/yaml.Unmarshal functions directly.
+type Config struct {
+	Address        string         `mapstructure:"address" yaml:"address" json:"address"`
+	UnixSocketPath string         `mapstructure:"unixSocketPath" yaml:"unixSocketPath" json:"unixSocketPath"`
+	Timeouts       TimeoutsConfig `mapstructure:"timeouts" yaml:"timeouts" json:"timeouts"`
+	Limits         LimitsConfig   `mapstructure:"limits" yaml:"limits" json:"limits"`
+	Log            LogConfig      `mapstructure:"log" yaml:"log" json:"log"`
+	TLS            TLSConfig      `mapstructure:"tls" yaml:"tls" json:"tls"`
+
+	keyPrefix string
+}
+
+var _ config.Config = (*Config)(nil)
+var _ config.KeyPrefixProvider = (*Config)(nil)
+
+// ConfigOption is a type for functional options for the Config.
+type ConfigOption func(*configOptions)
+
+type configOptions struct {
+	keyPrefix string
+}
+
+// WithKeyPrefix returns a ConfigOption that sets a key prefix for parsing configuration parameters.
+// This prefix will be used by config.Loader.
+func WithKeyPrefix(keyPrefix string) ConfigOption {
+	return func(o *configOptions) {
+		o.keyPrefix = keyPrefix
+	}
+}
+
+// NewConfig creates a new instance of the Config.
+func NewConfig(options ...ConfigOption) *Config {
+	opts := configOptions{keyPrefix: cfgDefaultKeyPrefix} // cfgDefaultKeyPrefix is used here for backward compatibility
+	for _, opt := range options {
+		opt(&opts)
+	}
+	return &Config{keyPrefix: opts.keyPrefix}
+}
+
+// NewConfigWithKeyPrefix creates a new instance of the Config with a key prefix.
+// This prefix will be used by config.Loader.
+// Deprecated: use NewConfig with WithKeyPrefix instead.
+func NewConfigWithKeyPrefix(keyPrefix string) *Config {
+	if keyPrefix != "" {
+		keyPrefix += "."
+	}
+	keyPrefix += cfgDefaultKeyPrefix // cfgDefaultKeyPrefix is added here for backward compatibility
+	return &Config{keyPrefix: keyPrefix}
+}
+
+// NewDefaultConfig creates a new instance of the Config with default values.
+func NewDefaultConfig(options ...ConfigOption) *Config {
+	opts := configOptions{keyPrefix: cfgDefaultKeyPrefix}
+	for _, opt := range options {
+		opt(&opts)
+	}
+	return &Config{
+		keyPrefix: opts.keyPrefix,
+		Address:   defaultServerAddress,
+		Timeouts: TimeoutsConfig{
+			Write:      config.TimeDuration(defaultServerTimeoutsWrite),
+			Read:       config.TimeDuration(defaultServerTimeoutsRead),
+			ReadHeader: config.TimeDuration(defaultServerTimeoutsReadHeader),
+			Idle:       config.TimeDuration(defaultServerTimeoutsIdle),
+			Shutdown:   config.TimeDuration(defaultServerTimeoutsShutdown),
+		},
+		Limits: LimitsConfig{
+			MaxRequests: defaultServerLimitsMaxRequests,
+		},
+		Log: LogConfig{
+			SlowRequestThreshold: config.TimeDuration(defaultSlowRequestThreshold),
+		},
+	}
+}
+
+// KeyPrefix returns a key prefix with which all configuration parameters should be presented.
+// Implements config.KeyPrefixProvider interface.
+func (c *Config) KeyPrefix() string {
+	if c.keyPrefix == "" {
+		return cfgDefaultKeyPrefix
+	}
+	return c.keyPrefix
+}
+
+// SetProviderDefaults sets default configuration values for HTTPServer in config.DataProvider.
+// Implements config.Config interface.
+func (c *Config) SetProviderDefaults(dp config.DataProvider) {
+	dp.SetDefault(cfgKeyServerAddress, defaultServerAddress)
+
+	dp.SetDefault(cfgKeyServerTimeoutsWrite, defaultServerTimeoutsWrite)
+	dp.SetDefault(cfgKeyServerTimeoutsRead, defaultServerTimeoutsRead)
+	dp.SetDefault(cfgKeyServerTimeoutsReadHeader, defaultServerTimeoutsReadHeader)
+	dp.SetDefault(cfgKeyServerTimeoutsIdle, defaultServerTimeoutsIdle)
+	dp.SetDefault(cfgKeyServerTimeoutsShutdown, defaultServerTimeoutsShutdown)
+
+	dp.SetDefault(cfgKeyServerLimitsMaxRequests, defaultServerLimitsMaxRequests)
+
+	dp.SetDefault(cfgKeyServerLogRequestStart, false)
+	dp.SetDefault(cfgKeyServerLogAddRequestInfo, false)
+	dp.SetDefault(cfgKeyServerLogSlowRequestThreshold, defaultSlowRequestThreshold)
+}
 
 // TimeoutsConfig represents a set of configuration parameters for HTTPServer relating to timeouts.
 type TimeoutsConfig struct {
-	Write      time.Duration
-	Read       time.Duration
-	ReadHeader time.Duration
-	Idle       time.Duration
-	Shutdown   time.Duration
+	Write      config.TimeDuration `mapstructure:"write" yaml:"write" json:"write"`
+	Read       config.TimeDuration `mapstructure:"read" yaml:"read" json:"read"`
+	ReadHeader config.TimeDuration `mapstructure:"readHeader" yaml:"readHeader" json:"readHeader"`
+	Idle       config.TimeDuration `mapstructure:"idle" yaml:"idle" json:"idle"`
+	Shutdown   config.TimeDuration `mapstructure:"shutdown" yaml:"shutdown" json:"shutdown"`
 }
 
 // Set sets timeout server configuration values from config.DataProvider.
+// Implements config.Config interface.
 func (t *TimeoutsConfig) Set(dp config.DataProvider) error {
 	var err error
+	var dur time.Duration
 
-	if t.Write, err = dp.GetDuration(cfgKeyServerTimeoutsWrite); err != nil {
+	if dur, err = dp.GetDuration(cfgKeyServerTimeoutsWrite); err != nil {
 		return err
 	}
-	if t.Read, err = dp.GetDuration(cfgKeyServerTimeoutsRead); err != nil {
+	t.Write = config.TimeDuration(dur)
+
+	if dur, err = dp.GetDuration(cfgKeyServerTimeoutsRead); err != nil {
 		return err
 	}
-	if t.ReadHeader, err = dp.GetDuration(cfgKeyServerTimeoutsReadHeader); err != nil {
+	t.Read = config.TimeDuration(dur)
+
+	if dur, err = dp.GetDuration(cfgKeyServerTimeoutsReadHeader); err != nil {
 		return err
 	}
-	if t.Idle, err = dp.GetDuration(cfgKeyServerTimeoutsIdle); err != nil {
+	t.ReadHeader = config.TimeDuration(dur)
+
+	if dur, err = dp.GetDuration(cfgKeyServerTimeoutsIdle); err != nil {
 		return err
 	}
-	if t.Shutdown, err = dp.GetDuration(cfgKeyServerTimeoutsShutdown); err != nil {
+	t.Idle = config.TimeDuration(dur)
+
+	if dur, err = dp.GetDuration(cfgKeyServerTimeoutsShutdown); err != nil {
 		return err
 	}
+	t.Shutdown = config.TimeDuration(dur)
 
 	return nil
 }
 
 // LimitsConfig represents a set of configuration parameters for HTTPServer relating to limits.
 type LimitsConfig struct {
-	MaxRequests      int
-	MaxBodySizeBytes uint64
+	// MaxRequests is the maximum number of requests that can be processed concurrently.
+	MaxRequests int `mapstructure:"maxRequests" yaml:"maxRequests" json:"maxRequests"`
+
+	// MaxBodySizeBytes is the maximum size of the request body in bytes.
+	MaxBodySizeBytes config.BytesCount `mapstructure:"maxBodySize" yaml:"maxBodySize" json:"maxBodySize"`
 }
 
 // Set sets limit server configuration values from config.DataProvider.
@@ -89,8 +210,12 @@ func (l *LimitsConfig) Set(dp config.DataProvider) error {
 	if l.MaxRequests, err = dp.GetInt(cfgKeyServerLimitsMaxRequests); err != nil {
 		return err
 	}
-	if l.MaxBodySizeBytes, err = dp.GetSizeInBytes(cfgKeyServerLimitsMaxBodySize); err != nil {
-		return err
+	if l.MaxRequests < 0 {
+		return dp.WrapKeyErr(cfgKeyServerLimitsMaxRequests, fmt.Errorf("maxRequests must be positive"))
+	}
+
+	if l.MaxBodySizeBytes, err = dp.GetBytesCount(cfgKeyServerLimitsMaxBodySize); err != nil {
+		return dp.WrapKeyErr(cfgKeyServerLimitsMaxBodySize, err)
 	}
 
 	return nil
@@ -98,12 +223,12 @@ func (l *LimitsConfig) Set(dp config.DataProvider) error {
 
 // LogConfig represents a set of configuration parameters for HTTPServer relating to logging.
 type LogConfig struct {
-	RequestStart           bool
-	RequestHeaders         []string
-	ExcludedEndpoints      []string
-	SecretQueryParams      []string
-	AddRequestInfoToLogger bool
-	SlowRequestThreshold   time.Duration
+	RequestStart           bool                `mapstructure:"requestStart" yaml:"requestStart" json:"requestStart"`
+	RequestHeaders         []string            `mapstructure:"requestHeaders" yaml:"requestHeaders" json:"requestHeaders"`
+	ExcludedEndpoints      []string            `mapstructure:"excludedEndpoints" yaml:"excludedEndpoints" json:"excludedEndpoints"`
+	SecretQueryParams      []string            `mapstructure:"secretQueryParams" yaml:"secretQueryParams"`
+	AddRequestInfoToLogger bool                `mapstructure:"addRequestInfo" yaml:"addRequestInfo" json:"addRequestInfo"`
+	SlowRequestThreshold   config.TimeDuration `mapstructure:"slowRequestThreshold" yaml:"slowRequestThreshold" json:"slowRequestThreshold"`
 }
 
 // Set sets log server configuration values from config.DataProvider.
@@ -125,18 +250,21 @@ func (l *LogConfig) Set(dp config.DataProvider) error {
 	if l.AddRequestInfoToLogger, err = dp.GetBool(cfgKeyServerLogAddRequestInfo); err != nil {
 		return err
 	}
-	if l.SlowRequestThreshold, err = dp.GetDuration(cfgKeyServerLogSlowRequestThreshold); err != nil {
+
+	var dur time.Duration
+	if dur, err = dp.GetDuration(cfgKeyServerLogSlowRequestThreshold); err != nil {
 		return err
 	}
+	l.SlowRequestThreshold = config.TimeDuration(dur)
 
 	return nil
 }
 
 // TLSConfig contains configuration parameters needed to initialize(or not) secure server
 type TLSConfig struct {
-	Enabled     bool
-	Certificate string
-	Key         string
+	Enabled     bool   `mapstructure:"enabled" yaml:"enabled" json:"enabled"`
+	Certificate string `mapstructure:"cert" yaml:"cert" json:"cert"`
+	Key         string `mapstructure:"key" yaml:"key" json:"key"`
 }
 
 // Set sets security server configuration values from config.DataProvider.
@@ -155,55 +283,11 @@ func (s *TLSConfig) Set(dp config.DataProvider) error {
 		return err
 	}
 
+	if s.Enabled && (s.Certificate == "" || s.Key == "") {
+		return dp.WrapKeyErr(cfgKeyServerTLSKey, fmt.Errorf("both cert and key should be set"))
+	}
+
 	return nil
-}
-
-// Config represents a set of configuration parameters for HTTPServer.
-type Config struct {
-	Address        string
-	UnixSocketPath string
-	Timeouts       TimeoutsConfig
-	Limits         LimitsConfig
-	Log            LogConfig
-	TLS            TLSConfig
-
-	keyPrefix string
-}
-
-var _ config.Config = (*Config)(nil)
-var _ config.KeyPrefixProvider = (*Config)(nil)
-
-// NewConfig creates a new instance of the Config.
-func NewConfig() *Config {
-	return NewConfigWithKeyPrefix("")
-}
-
-// NewConfigWithKeyPrefix creates a new instance of the Config.
-// Allows specifying key prefix which will be used for parsing configuration parameters.
-func NewConfigWithKeyPrefix(keyPrefix string) *Config {
-	return &Config{keyPrefix: keyPrefix}
-}
-
-// KeyPrefix returns a key prefix with which all configuration parameters should be presented.
-func (c *Config) KeyPrefix() string {
-	return c.keyPrefix
-}
-
-// SetProviderDefaults sets default configuration values for HTTPServer in config.DataProvider.
-func (c *Config) SetProviderDefaults(dp config.DataProvider) {
-	dp.SetDefault(cfgKeyServerAddress, defaultServerAddress)
-
-	dp.SetDefault(cfgKeyServerTimeoutsWrite, defaultServerTimeoutsWrite)
-	dp.SetDefault(cfgKeyServerTimeoutsRead, defaultServerTimeoutsRead)
-	dp.SetDefault(cfgKeyServerTimeoutsReadHeader, defaultServerTimeoutsReadHeader)
-	dp.SetDefault(cfgKeyServerTimeoutsIdle, defaultServerTimeoutsIdle)
-	dp.SetDefault(cfgKeyServerTimeoutsShutdown, defaultServerTimeoutsShutdown)
-
-	dp.SetDefault(cfgKeyServerLimitsMaxRequests, defaultServerLimitsMaxRequests)
-
-	dp.SetDefault(cfgKeyServerLogRequestStart, false)
-	dp.SetDefault(cfgKeyServerLogAddRequestInfo, false)
-	dp.SetDefault(cfgKeyServerLogSlowRequestThreshold, defaultSlowRequestThreshold)
 }
 
 // Set sets HTTPServer configuration values from config.DataProvider.
@@ -215,6 +299,9 @@ func (c *Config) Set(dp config.DataProvider) error {
 	}
 	if c.UnixSocketPath, err = dp.GetString(cfgKeyServerUnixSocketPath); err != nil {
 		return err
+	}
+	if c.Address == "" && c.UnixSocketPath == "" {
+		return dp.WrapKeyErr(cfgKeyServerAddress, fmt.Errorf("either address or unixSocketPath should be set"))
 	}
 
 	err = c.TLS.Set(dp)

--- a/httpserver/http_server.go
+++ b/httpserver/http_server.go
@@ -122,10 +122,10 @@ func New(cfg *Config, logger log.FieldLogger, opts Opts) (*HTTPServer, error) { 
 func NewWithHandler(cfg *Config, logger log.FieldLogger, handler http.Handler) *HTTPServer {
 	httpServer := &http.Server{
 		Addr:              cfg.Address,
-		WriteTimeout:      cfg.Timeouts.Write,
-		ReadTimeout:       cfg.Timeouts.Read,
-		ReadHeaderTimeout: cfg.Timeouts.ReadHeader,
-		IdleTimeout:       cfg.Timeouts.Idle,
+		WriteTimeout:      time.Duration(cfg.Timeouts.Write),
+		ReadTimeout:       time.Duration(cfg.Timeouts.Read),
+		ReadHeaderTimeout: time.Duration(cfg.Timeouts.ReadHeader),
+		IdleTimeout:       time.Duration(cfg.Timeouts.Idle),
 		Handler:           handler,
 	}
 
@@ -148,7 +148,7 @@ func NewWithHandler(cfg *Config, logger log.FieldLogger, handler http.Handler) *
 		UnixSocketPath:  cfg.UnixSocketPath,
 		Logger:          logger,
 		TLS:             cfg.TLS,
-		ShutdownTimeout: cfg.Timeouts.Shutdown,
+		ShutdownTimeout: time.Duration(cfg.Timeouts.Shutdown),
 		HTTPRouter:      router,
 	}
 }

--- a/httpserver/http_server_test.go
+++ b/httpserver/http_server_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/stretchr/testify/require"
 
+	"github.com/acronis/go-appkit/config"
 	"github.com/acronis/go-appkit/httpserver/middleware"
 	"github.com/acronis/go-appkit/log"
 	"github.com/acronis/go-appkit/log/logtest"
@@ -300,7 +301,11 @@ func TestHTTPServer_Stop(t *testing.T) {
 	t.Run("with gracefully shutdown", func(t *testing.T) {
 		addr := testutil.GetLocalAddrWithFreeTCPPort()
 
-		httpServer, err := New(&Config{Address: addr, Timeouts: TimeoutsConfig{Shutdown: time.Second * 3}}, logtest.NewLogger(), opts)
+		serverCfg := &Config{
+			Address:  addr,
+			Timeouts: TimeoutsConfig{Shutdown: config.TimeDuration(time.Second * 3)},
+		}
+		httpServer, err := New(serverCfg, logtest.NewLogger(), opts)
 		require.NoError(t, err)
 		fatalErr := make(chan error, 1)
 		go httpServer.Start(fatalErr)
@@ -333,7 +338,8 @@ func TestHTTPServer_Stop(t *testing.T) {
 	t.Run("w/o gracefully shutdown", func(t *testing.T) {
 		addr := testutil.GetLocalAddrWithFreeTCPPort()
 
-		httpServer, err := New(&Config{Address: addr, Timeouts: TimeoutsConfig{Shutdown: time.Second * 3}}, logtest.NewLogger(), opts)
+		serverCfg := &Config{Address: addr, Timeouts: TimeoutsConfig{Shutdown: config.TimeDuration(time.Second * 3)}}
+		httpServer, err := New(serverCfg, logtest.NewLogger(), opts)
 		require.NoError(t, err)
 		fatalErr := make(chan error, 1)
 		go httpServer.Start(fatalErr)
@@ -375,17 +381,17 @@ func TestHTTPServer_Stop_Without_Start(t *testing.T) {
 
 	t.Run("with graceful shutdown", func(t *testing.T) {
 		addr := testutil.GetLocalAddrWithFreeTCPPort()
-		httpServer, err := New(&Config{Address: addr, Timeouts: TimeoutsConfig{Shutdown: time.Second * 3}}, logtest.NewLogger(), opts)
+		serverCfg := &Config{Address: addr, Timeouts: TimeoutsConfig{Shutdown: config.TimeDuration(time.Second * 3)}}
+		httpServer, err := New(serverCfg, logtest.NewLogger(), opts)
 		require.NoError(t, err)
-
 		require.NoError(t, httpServer.Stop(true))
 	})
 
 	t.Run("w/o graceful shutdown", func(t *testing.T) {
 		addr := testutil.GetLocalAddrWithFreeTCPPort()
-		httpServer, err := New(&Config{Address: addr, Timeouts: TimeoutsConfig{Shutdown: time.Second * 3}}, logtest.NewLogger(), opts)
+		serverCfg := &Config{Address: addr, Timeouts: TimeoutsConfig{Shutdown: config.TimeDuration(time.Second * 3)}}
+		httpServer, err := New(serverCfg, logtest.NewLogger(), opts)
 		require.NoError(t, err)
-
 		require.NoError(t, httpServer.Stop(false))
 	})
 }

--- a/httpserver/middleware/throttle/middleware.go
+++ b/httpserver/middleware/throttle/middleware.go
@@ -289,7 +289,7 @@ func makeRateLimitMiddleware(
 		GetKey:             getKey,
 		MaxKeys:            cfg.MaxKeys,
 		BacklogLimit:       cfg.BacklogLimit,
-		BacklogTimeout:     cfg.BacklogTimeout,
+		BacklogTimeout:     time.Duration(cfg.BacklogTimeout),
 		ResponseStatusCode: cfg.getResponseStatusCode(),
 		GetRetryAfter:      getRetryAfter,
 		DryRun:             cfg.DryRun,
@@ -334,7 +334,7 @@ func makeInFlightLimitMiddleware(
 	var getRetryAfter func(r *http.Request) time.Duration
 	if cfg.ResponseRetryAfter != 0 {
 		getRetryAfter = func(_ *http.Request) time.Duration {
-			return cfg.ResponseRetryAfter
+			return time.Duration(cfg.ResponseRetryAfter)
 		}
 	}
 
@@ -372,7 +372,7 @@ func makeInFlightLimitMiddleware(
 		ResponseStatusCode: cfg.getResponseStatusCode(),
 		GetRetryAfter:      getRetryAfter,
 		BacklogLimit:       cfg.BacklogLimit,
-		BacklogTimeout:     cfg.BacklogTimeout,
+		BacklogTimeout:     time.Duration(cfg.BacklogTimeout),
 		DryRun:             cfg.DryRun,
 		OnReject:           onRejectWithMetrics,
 		OnRejectInDryRun:   onRejectInDryRunWithMetrics,

--- a/httpserver/middleware/throttle/middleware_test.go
+++ b/httpserver/middleware/throttle/middleware_test.go
@@ -552,8 +552,7 @@ rules:
 		},
 	}
 	configLoader := config.NewLoader(config.NewViperAdapter())
-	for i := range tests {
-		tt := tests[i]
+	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			cfg := &Config{}
 			err := configLoader.LoadFromReader(bytes.NewReader([]byte(tt.CfgData)), config.DataTypeYAML, cfg)

--- a/httpserver/router.go
+++ b/httpserver/router.go
@@ -92,7 +92,7 @@ func applyDefaultMiddlewaresToRouter(
 		ExcludedEndpoints:      cfg.Log.ExcludedEndpoints,
 		SecretQueryParams:      cfg.Log.SecretQueryParams,
 		AddRequestInfoToLogger: cfg.Log.AddRequestInfoToLogger,
-		SlowRequestThreshold:   cfg.Log.SlowRequestThreshold,
+		SlowRequestThreshold:   time.Duration(cfg.Log.SlowRequestThreshold),
 	}
 	for _, headerName := range cfg.Log.RequestHeaders {
 		logFieldKey := "req_header_" + strings.ToLower(strings.ReplaceAll(headerName, "-", "_"))
@@ -136,7 +136,7 @@ func applyDefaultMiddlewaresToRouter(
 
 	// Middleware to limit max request body.
 	if cfg.Limits.MaxBodySizeBytes > 0 {
-		router.Use(middleware.RequestBodyLimit(cfg.Limits.MaxBodySizeBytes, opts.ErrorDomain))
+		router.Use(middleware.RequestBodyLimit(uint64(cfg.Limits.MaxBodySizeBytes), opts.ErrorDomain))
 	}
 
 	return nil

--- a/log/config.go
+++ b/log/config.go
@@ -194,11 +194,11 @@ type FileOutputConfig struct {
 
 // FileRotationConfig is a configuration for file log rotation.
 type FileRotationConfig struct {
-	Compress         bool              `mapstructure:"compress" yaml:"compress" json:"compress"`
-	MaxSize          config.BytesCount `mapstructure:"maxSize" yaml:"maxSize" json:"maxSize"`
-	MaxBackups       int               `mapstructure:"maxBackups" yaml:"maxBackups" json:"maxBackups"`
-	MaxAgeDays       int               `mapstructure:"maxAgeDays" yaml:"maxAgeDays" json:"maxAgeDays"`
-	LocalTimeInNames bool              `mapstructure:"localTimeInNames" yaml:"localTimeInNames" json:"localTimeInNames"`
+	Compress         bool            `mapstructure:"compress" yaml:"compress" json:"compress"`
+	MaxSize          config.ByteSize `mapstructure:"maxSize" yaml:"maxSize" json:"maxSize"`
+	MaxBackups       int             `mapstructure:"maxBackups" yaml:"maxBackups" json:"maxBackups"`
+	MaxAgeDays       int             `mapstructure:"maxAgeDays" yaml:"maxAgeDays" json:"maxAgeDays"`
+	LocalTimeInNames bool            `mapstructure:"localTimeInNames" yaml:"localTimeInNames" json:"localTimeInNames"`
 }
 
 type ErrorConfig struct {
@@ -309,7 +309,7 @@ func (c *Config) setFileOutputConfig(dp config.DataProvider) error {
 		return err
 	}
 
-	if c.File.Rotation.MaxSize, err = dp.GetBytesCount(cfgKeyFileRotationMaxSize); err != nil {
+	if c.File.Rotation.MaxSize, err = dp.GetSizeInBytes(cfgKeyFileRotationMaxSize); err != nil {
 		return err
 	}
 	if c.File.Rotation.MaxSize < MinFileRotationMaxSizeBytes {

--- a/log/config.go
+++ b/log/config.go
@@ -8,27 +8,32 @@ package log
 
 import (
 	"fmt"
+	"strings"
 
 	"code.cloudfoundry.org/bytefmt"
 
 	"github.com/acronis/go-appkit/config"
 )
 
+const cfgDefaultKeyPrefix = "log"
+
 const (
-	cfgKeyLevel                        = "log.level"
-	cfgKeyFormat                       = "log.format"
-	cfgKeyOutput                       = "log.output"
-	cfgKeyNoColor                      = "log.nocolor"
-	cfgKeyFilePath                     = "log.file.path"
-	cfgKeyFileRotationCompress         = "log.file.rotation.compress"
-	cfgKeyFileRotationMaxSize          = "log.file.rotation.maxSize"
-	cfgKeyFileRotationMaxBackups       = "log.file.rotation.maxBackups"
-	cfgKeyFileRotationMaxAgeDays       = "log.file.rotation.maxAgeDays"
-	cfgKeyFileRotationLocalTimeInNames = "log.file.rotation.localTimeInNames"
-	cfgKeyAddCaller                    = "log.addCaller"
-	cfgKeyErrorNoVerbose               = "log.error.noVerbose"
-	cfgKeyErrorVerboseSuffix           = "log.error.verboseSuffix"
-	cfgKeyMasking                      = "log.masking"
+	cfgKeyLevel                        = "level"
+	cfgKeyFormat                       = "format"
+	cfgKeyOutput                       = "output"
+	cfgKeyNoColor                      = "nocolor"
+	cfgKeyFilePath                     = "file.path"
+	cfgKeyFileRotationCompress         = "file.rotation.compress"
+	cfgKeyFileRotationMaxSize          = "file.rotation.maxSize"
+	cfgKeyFileRotationMaxBackups       = "file.rotation.maxBackups"
+	cfgKeyFileRotationMaxAgeDays       = "file.rotation.maxAgeDays"
+	cfgKeyFileRotationLocalTimeInNames = "file.rotation.localTimeInNames"
+	cfgKeyAddCaller                    = "addCaller"
+	cfgKeyErrorNoVerbose               = "error.noVerbose"
+	cfgKeyErrorVerboseSuffix           = "error.verboseSuffix"
+	cfgKeyMaskingEnabled               = "masking.enabled"
+	cfgKeyMaskingUseDefaultRules       = "masking.useDefaultRules"
+	cfgKeyMaskingRules                 = "masking.rules"
 )
 
 // Default and restriction values.
@@ -38,33 +43,107 @@ const (
 
 	DefaultFileRotationMaxBackups = 10
 	MinFileRotationMaxBackups     = 1
+
+	defaultErrorVerboseSuffix = "_verbose"
 )
 
 // Config represents a set of configuration parameters for logging.
+// Configuration can be loaded in different formats (YAML, JSON) using config.Loader, viper,
+// or with json.Unmarshal/yaml.Unmarshal functions directly.
 type Config struct {
-	Level   Level
-	Format  Format
-	Output  Output
-	NoColor bool
-	File    FileOutputConfig
+	Level   Level            `mapstructure:"level" yaml:"level" json:"level"`
+	Format  Format           `mapstructure:"format" yaml:"format" json:"format"`
+	Output  Output           `mapstructure:"output" yaml:"output" json:"output"`
+	NoColor bool             `mapstructure:"nocolor" yaml:"nocolor" json:"nocolor"`
+	File    FileOutputConfig `mapstructure:"file" yaml:"file" json:"file"`
 
-	// ErrorNoVerbose determines whether the verbose error message will be added to each logged error message.
-	// If true, or if the verbose error message is equal to the plain error message (err.Error()),
-	// no verbose error message will be added.
-	// Otherwise, if the logged error implements the fmt.Formatter interface,
-	// the verbose error message will be added as a separate field with the key "error" + ErrorVerboseSuffix.
-	ErrorNoVerbose     bool
-	ErrorVerboseSuffix string
+	Error ErrorConfig `mapstructure:"error" yaml:"error" json:"error"`
 
 	// AddCaller determines whether the caller (in package/file:line format) will be added to each logged message.
 	//
 	// Example of log with caller:
 	// 	{"level":"info","time":"...","msg":"starting application HTTP server...","caller":"httpserver/http_server.go:98","address":":8888"}
-	AddCaller bool
+	AddCaller bool `mapstructure:"addCaller" yaml:"addCaller" json:"addCaller"`
 
-	Masking MaskingConfig
+	Masking MaskingConfig `mapstructure:"masking" yaml:"masking" json:"masking"`
 
 	keyPrefix string
+}
+
+var _ config.Config = (*Config)(nil)
+var _ config.KeyPrefixProvider = (*Config)(nil)
+
+// ConfigOption is a type for functional options for the Config.
+type ConfigOption func(*configOptions)
+
+type configOptions struct {
+	keyPrefix string
+}
+
+// WithKeyPrefix returns a ConfigOption that sets a key prefix for parsing configuration parameters.
+// This prefix will be used by config.Loader.
+func WithKeyPrefix(keyPrefix string) ConfigOption {
+	return func(o *configOptions) {
+		o.keyPrefix = keyPrefix
+	}
+}
+
+// NewConfig creates a new instance of the Config.
+func NewConfig(options ...ConfigOption) *Config {
+	var opts = configOptions{keyPrefix: cfgDefaultKeyPrefix} // cfgDefaultKeyPrefix is used here for backward compatibility
+	for _, opt := range options {
+		opt(&opts)
+	}
+	return &Config{keyPrefix: opts.keyPrefix}
+}
+
+// NewConfigWithKeyPrefix creates a new instance of the Config with a key prefix.
+// This prefix will be used by config.Loader.
+// Deprecated: use NewConfig with WithKeyPrefix instead.
+func NewConfigWithKeyPrefix(keyPrefix string) *Config {
+	if keyPrefix != "" {
+		keyPrefix += "."
+	}
+	keyPrefix += cfgDefaultKeyPrefix // cfgDefaultKeyPrefix is added here for backward compatibility
+	return &Config{keyPrefix: keyPrefix}
+}
+
+// NewDefaultConfig creates a new instance of the Config with default values.
+func NewDefaultConfig(options ...ConfigOption) *Config {
+	opts := configOptions{keyPrefix: cfgDefaultKeyPrefix}
+	for _, opt := range options {
+		opt(&opts)
+	}
+	return &Config{
+		keyPrefix: opts.keyPrefix,
+		Level:     LevelInfo,
+		Format:    FormatJSON,
+		Output:    OutputStdout,
+		File: FileOutputConfig{
+			Rotation: FileRotationConfig{
+				MaxSize:    DefaultFileRotationMaxSizeBytes,
+				MaxBackups: DefaultFileRotationMaxBackups,
+			},
+		},
+		Error: ErrorConfig{
+			VerboseSuffix: defaultErrorVerboseSuffix,
+		},
+		Masking: MaskingConfig{
+			UseDefaultRules: true,
+		},
+	}
+}
+
+// SetProviderDefaults sets default configuration values for logger in config.DataProvider.
+// Implements config.Config interface.
+func (c *Config) SetProviderDefaults(dp config.DataProvider) {
+	dp.SetDefault(cfgKeyLevel, string(LevelInfo))
+	dp.SetDefault(cfgKeyFormat, string(FormatJSON))
+	dp.SetDefault(cfgKeyOutput, string(OutputStdout))
+	dp.SetDefault(cfgKeyErrorVerboseSuffix, defaultErrorVerboseSuffix)
+	dp.SetDefault(cfgKeyFileRotationMaxSize, bytefmt.ByteSize(DefaultFileRotationMaxSizeBytes))
+	dp.SetDefault(cfgKeyFileRotationMaxBackups, DefaultFileRotationMaxBackups)
+	dp.SetDefault(cfgKeyMaskingUseDefaultRules, true)
 }
 
 // Level defines possible values for log levels.
@@ -97,52 +176,68 @@ const (
 	OutputFile   Output = "file"
 )
 
+// FieldMaskFormat defines possible values for field mask formats.
+type FieldMaskFormat string
+
+// Field mask formats.
+const (
+	FieldMaskFormatHTTPHeader FieldMaskFormat = "http_header"
+	FieldMaskFormatJSON       FieldMaskFormat = "json"
+	FieldMaskFormatURLEncoded FieldMaskFormat = "urlencoded"
+)
+
 // FileOutputConfig is a configuration for file log output.
 type FileOutputConfig struct {
-	Path     string
-	Rotation FileRotationConfig
+	Path     string             `mapstructure:"path" yaml:"path" json:"path"`
+	Rotation FileRotationConfig `mapstructure:"rotation" yaml:"rotation" json:"rotation"`
 }
 
 // FileRotationConfig is a configuration for file log rotation.
 type FileRotationConfig struct {
-	Compress         bool
-	MaxSize          uint64
-	MaxBackups       int
-	MaxAgeDays       int
-	LocalTimeInNames bool
+	Compress         bool              `mapstructure:"compress" yaml:"compress" json:"compress"`
+	MaxSize          config.BytesCount `mapstructure:"maxSize" yaml:"maxSize" json:"maxSize"`
+	MaxBackups       int               `mapstructure:"maxBackups" yaml:"maxBackups" json:"maxBackups"`
+	MaxAgeDays       int               `mapstructure:"maxAgeDays" yaml:"maxAgeDays" json:"maxAgeDays"`
+	LocalTimeInNames bool              `mapstructure:"localTimeInNames" yaml:"localTimeInNames" json:"localTimeInNames"`
 }
 
-var _ config.Config = (*Config)(nil)
-var _ config.KeyPrefixProvider = (*Config)(nil)
-
-// NewConfig creates a new instance of the Config.
-func NewConfig() *Config {
-	return NewConfigWithKeyPrefix("")
+type ErrorConfig struct {
+	// NoVerbose determines whether the verbose error message will be added to each logged error message.
+	// If true, or if the verbose error message is equal to the plain error message (err.Error()),
+	// no verbose error message will be added.
+	// Otherwise, if the logged error implements the fmt.Formatter interface,
+	// the verbose error message will be added as a separate field with the key "error" + VerboseSuffix.
+	NoVerbose     bool   `mapstructure:"noVerbose" yaml:"noVerbose" json:"noVerbose"`
+	VerboseSuffix string `mapstructure:"verboseSuffix" yaml:"verboseSuffix" json:"verboseSuffix"`
 }
 
-// NewConfigWithKeyPrefix creates a new instance of the Config.
-// Allows to specify key prefix which will be used for parsing configuration parameters.
-func NewConfigWithKeyPrefix(keyPrefix string) *Config {
-	return &Config{keyPrefix: keyPrefix}
+// MaskingConfig is a configuration for log field masking.
+type MaskingConfig struct {
+	Enabled         bool                `mapstructure:"enabled" yaml:"enabled" json:"enabled"`
+	UseDefaultRules bool                `mapstructure:"useDefaultRules" yaml:"useDefaultRules" json:"useDefaultRules"`
+	Rules           []MaskingRuleConfig `mapstructure:"rules" yaml:"rules" json:"rules"`
+}
+
+// MaskingRuleConfig is a configuration for a single masking rule.
+type MaskingRuleConfig struct {
+	Field   string            `mapstructure:"field" yaml:"field" json:"field"`
+	Formats []FieldMaskFormat `mapstructure:"formats" yaml:"formats" json:"formats"`
+	Masks   []MaskConfig      `mapstructure:"masks" yaml:"masks" json:"masks"`
+}
+
+// MaskConfig is a configuration for a single mask.
+type MaskConfig struct {
+	RegExp string `mapstructure:"regexp" yaml:"regexp" json:"regexp"`
+	Mask   string `mapstructure:"mask" yaml:"mask" json:"mask"`
 }
 
 // KeyPrefix returns a key prefix with which all configuration parameters should be presented.
+// Implements config.KeyPrefixProvider interface.
 func (c *Config) KeyPrefix() string {
+	if c.keyPrefix == "" {
+		return cfgDefaultKeyPrefix
+	}
 	return c.keyPrefix
-}
-
-// SetProviderDefaults sets default configuration values for logger in config.DataProvider.
-func (c *Config) SetProviderDefaults(dp config.DataProvider) {
-	dp.SetDefault(cfgKeyLevel, string(LevelInfo))
-	dp.SetDefault(cfgKeyFormat, string(FormatJSON))
-	dp.SetDefault(cfgKeyOutput, string(OutputStdout))
-	dp.SetDefault(cfgKeyNoColor, false)
-	dp.SetDefault(cfgKeyFileRotationCompress, false)
-	dp.SetDefault(cfgKeyFileRotationMaxSize, bytefmt.ByteSize(DefaultFileRotationMaxSizeBytes))
-	dp.SetDefault(cfgKeyFileRotationMaxBackups, DefaultFileRotationMaxBackups)
-	dp.SetDefault(cfgKeyErrorNoVerbose, false)
-	dp.SetDefault(cfgKeyErrorVerboseSuffix, "_verbose")
-	c.Masking.SetProviderDefaults(config.NewKeyPrefixedDataProvider(dp, cfgKeyMasking))
 }
 
 var (
@@ -152,6 +247,7 @@ var (
 )
 
 // Set sets logger configuration values from config.DataProvider.
+// Implements config.Config interface.
 func (c *Config) Set(dp config.DataProvider) error {
 	var err error
 
@@ -159,19 +255,19 @@ func (c *Config) Set(dp config.DataProvider) error {
 	if levelStr, err = dp.GetStringFromSet(cfgKeyLevel, availableLevels, true); err != nil {
 		return err
 	}
-	c.Level = Level(levelStr)
+	c.Level = Level(strings.ToLower(levelStr))
 
 	var formatStr string
-	if formatStr, err = dp.GetStringFromSet(cfgKeyFormat, availableFormats, false); err != nil {
+	if formatStr, err = dp.GetStringFromSet(cfgKeyFormat, availableFormats, true); err != nil {
 		return err
 	}
-	c.Format = Format(formatStr)
+	c.Format = Format(strings.ToLower(formatStr))
 
 	var outputStr string
-	if outputStr, err = dp.GetStringFromSet(cfgKeyOutput, availableOutputs, false); err != nil {
+	if outputStr, err = dp.GetStringFromSet(cfgKeyOutput, availableOutputs, true); err != nil {
 		return err
 	}
-	c.Output = Output(outputStr)
+	c.Output = Output(strings.ToLower(outputStr))
 
 	if outputCfgErr := c.setFileOutputConfig(dp); outputCfgErr != nil {
 		return outputCfgErr
@@ -185,13 +281,14 @@ func (c *Config) Set(dp config.DataProvider) error {
 		return err
 	}
 
-	if c.ErrorNoVerbose, err = dp.GetBool(cfgKeyErrorNoVerbose); err != nil {
+	if c.Error.NoVerbose, err = dp.GetBool(cfgKeyErrorNoVerbose); err != nil {
 		return err
 	}
-	if c.ErrorVerboseSuffix, err = dp.GetString(cfgKeyErrorVerboseSuffix); err != nil {
+	if c.Error.VerboseSuffix, err = dp.GetString(cfgKeyErrorVerboseSuffix); err != nil {
 		return err
 	}
-	if err := c.Masking.Set(config.NewKeyPrefixedDataProvider(dp, cfgKeyMasking)); err != nil {
+
+	if err := c.setMaskingConfig(dp); err != nil {
 		return err
 	}
 	return nil
@@ -212,7 +309,7 @@ func (c *Config) setFileOutputConfig(dp config.DataProvider) error {
 		return err
 	}
 
-	if c.File.Rotation.MaxSize, err = dp.GetSizeInBytes(cfgKeyFileRotationMaxSize); err != nil {
+	if c.File.Rotation.MaxSize, err = dp.GetBytesCount(cfgKeyFileRotationMaxSize); err != nil {
 		return err
 	}
 	if c.File.Rotation.MaxSize < MinFileRotationMaxSizeBytes {
@@ -242,48 +339,14 @@ func (c *Config) setFileOutputConfig(dp config.DataProvider) error {
 	return nil
 }
 
-type MaskingConfig struct {
-	Enabled         bool
-	UseDefaultRules bool
-	Rules           []MaskingRuleConfig
-}
-
-type MaskingRuleConfig struct {
-	Field   string            `mapstructure:"field"`
-	Formats []FieldMaskFormat `mapstructure:"formats"`
-	Masks   []MaskConfig      `mapstructure:"masks"`
-}
-
-type MaskConfig struct {
-	RegExp string `mapstructure:"regexp"`
-	Mask   string `mapstructure:"mask"`
-}
-
-type FieldMaskFormat string
-
-const (
-	FieldMaskFormatHTTPHeader FieldMaskFormat = "http_header"
-	FieldMaskFormatJSON       FieldMaskFormat = "json"
-	FieldMaskFormatURLEncoded FieldMaskFormat = "urlencoded"
-
-	cfgKeyMaskingEnabled         = "enabled"
-	cfgKeyMaskingUseDefaultRules = "useDefaultRules"
-	cfgKeyMaskingRules           = "rules"
-)
-
-func (c *MaskingConfig) SetProviderDefaults(dp config.DataProvider) {
-	dp.SetDefault(cfgKeyMaskingUseDefaultRules, true)
-}
-
-// Set sets logger configuration values from config.DataProvider.
-func (c *MaskingConfig) Set(dp config.DataProvider) (err error) {
-	if c.Enabled, err = dp.GetBool(cfgKeyMaskingEnabled); err != nil {
+func (c *Config) setMaskingConfig(dp config.DataProvider) (err error) {
+	if c.Masking.Enabled, err = dp.GetBool(cfgKeyMaskingEnabled); err != nil {
 		return err
 	}
-	if c.UseDefaultRules, err = dp.GetBool(cfgKeyMaskingUseDefaultRules); err != nil {
+	if c.Masking.UseDefaultRules, err = dp.GetBool(cfgKeyMaskingUseDefaultRules); err != nil {
 		return err
 	}
-	if err := dp.UnmarshalKey(cfgKeyMaskingRules, &c.Rules); err != nil {
+	if err := dp.UnmarshalKey(cfgKeyMaskingRules, &c.Masking.Rules); err != nil {
 		return err
 	}
 	return nil

--- a/log/config_test.go
+++ b/log/config_test.go
@@ -8,32 +8,32 @@ package log
 
 import (
 	"bytes"
+	"encoding/json"
 	"testing"
 
+	"github.com/mitchellh/mapstructure"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	"github.com/acronis/go-appkit/config"
 )
 
-func TestConfig(t *testing.T) {
-	t.Run("default values", func(t *testing.T) {
-		cfgData := bytes.NewBuffer(nil)
-		cfg := Config{}
-		err := config.NewDefaultLoader("").LoadFromReader(cfgData, config.DataTypeYAML, &cfg)
-		require.NoError(t, err)
-		require.Equal(t, LevelInfo, cfg.Level)
-		require.Equal(t, FormatJSON, cfg.Format)
-		require.Equal(t, OutputStdout, cfg.Output)
-		require.Equal(t, "", cfg.File.Path)
-		require.Equal(t, DefaultFileRotationMaxSizeBytes, int(cfg.File.Rotation.MaxSize))
-		require.Equal(t, DefaultFileRotationMaxBackups, cfg.File.Rotation.MaxBackups)
-		require.False(t, cfg.File.Rotation.Compress)
-		require.False(t, cfg.ErrorNoVerbose)
-		require.Equal(t, "_verbose", cfg.ErrorVerboseSuffix)
-	})
+type AppConfig struct {
+	Log *Config `mapstructure:"log" json:"log" yaml:"log"`
+}
 
-	t.Run("read values", func(t *testing.T) {
-		cfgData := bytes.NewBuffer([]byte(`
+func TestConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfgDataType config.DataType
+		cfgData     string
+		expectedCfg func() *Config
+	}{
+		{
+			name:        "yaml config",
+			cfgDataType: config.DataTypeYAML,
+			cfgData: `
 log:
   level: warn
   format: text
@@ -42,132 +42,280 @@ log:
     path: my-service.log
     rotation:
       compress: true
-      maxsize: 100M
-      maxbackups: 42
-  addcaller: true
+      maxSize: 100M
+      maxBackups: 42
+  addCaller: true
   error:
-    noverbose: true
-    verbosesuffix: test-suffix
-`))
-		cfg := Config{}
-		err := config.NewDefaultLoader("").LoadFromReader(cfgData, config.DataTypeYAML, &cfg)
-		require.NoError(t, err)
-		require.Equal(t, LevelWarn, cfg.Level)
-		require.Equal(t, FormatText, cfg.Format)
-		require.Equal(t, OutputFile, cfg.Output)
-		require.Equal(t, "my-service.log", cfg.File.Path)
-		require.True(t, cfg.ErrorNoVerbose)
-		require.Equal(t, "test-suffix", cfg.ErrorVerboseSuffix)
-		require.Equal(t, 100*1024*1024, int(cfg.File.Rotation.MaxSize))
-		require.Equal(t, 42, cfg.File.Rotation.MaxBackups)
-		require.True(t, cfg.File.Rotation.Compress)
-		require.True(t, cfg.AddCaller)
-		require.False(t, cfg.Masking.Enabled)
-		require.True(t, cfg.Masking.UseDefaultRules)
-		require.Nil(t, cfg.Masking.Rules)
-	})
-
-	t.Run("errors", func(t *testing.T) {
-		var cfgData *bytes.Buffer
-		var cfg Config
-		var err error
-
-		cfgData = bytes.NewBuffer([]byte(`
-log:
-  level: invalid-level
-`))
-		cfg = Config{}
-		err = config.NewDefaultLoader("").LoadFromReader(cfgData, config.DataTypeYAML, &cfg)
-		require.EqualError(t, err, `log.level: unknown value "invalid-level", should be one of [error warn info debug]`)
-
-		cfgData = bytes.NewBuffer([]byte(`
-log:
-  format: invalid-format
-`))
-		cfg = Config{}
-		err = config.NewDefaultLoader("").LoadFromReader(cfgData, config.DataTypeYAML, &cfg)
-		require.EqualError(t, err, `log.format: unknown value "invalid-format", should be one of [json text]`)
-
-		cfgData = bytes.NewBuffer([]byte(`
-log:
-  output: invalid-output
-`))
-		cfg = Config{}
-		err = config.NewDefaultLoader("").LoadFromReader(cfgData, config.DataTypeYAML, &cfg)
-		require.EqualError(t, err, `log.output: unknown value "invalid-output", should be one of [stdout stderr file]`)
-
-		cfgData = bytes.NewBuffer([]byte(`
-log:
-  output: file
-`))
-		cfg = Config{}
-		err = config.NewDefaultLoader("").LoadFromReader(cfgData, config.DataTypeYAML, &cfg)
-		require.EqualError(t, err, `log.file.path: cannot be empty when "file" output is used`)
-	})
-}
-
-func TestMaskingConfig(t *testing.T) {
-	for _, tc := range []struct {
-		name    string
-		cfg     string
-		masking MaskingConfig
-	}{
-		{
-			name: "enable default",
-			cfg: `
-log:
-  masking:
-    enabled: true`,
-			masking: MaskingConfig{Enabled: true, UseDefaultRules: true, Rules: nil},
-		},
-		{
-			name: "default with custom rules",
-			cfg: `
-log:
-  masking:
-    enabled: true
-    useDefaultRules: true
-    rules:
-      - field: "api_key"
-        formats: ["http_header", "json", "urlencoded"]`,
-			masking: MaskingConfig{
-				Enabled: true, UseDefaultRules: true, Rules: []MaskingRuleConfig{
-					{
-						Field:   "api_key",
-						Formats: []FieldMaskFormat{FieldMaskFormatHTTPHeader, FieldMaskFormatJSON, FieldMaskFormatURLEncoded},
-					},
-				},
+    noVerbose: true
+    verboseSuffix: test-suffix
+`,
+			expectedCfg: func() *Config {
+				cfg := NewDefaultConfig()
+				cfg.Level = LevelWarn
+				cfg.Format = FormatText
+				cfg.Output = OutputFile
+				cfg.File.Path = "my-service.log"
+				cfg.File.Rotation.MaxSize = 100 * 1024 * 1024
+				cfg.File.Rotation.MaxBackups = 42
+				cfg.File.Rotation.Compress = true
+				cfg.AddCaller = true
+				cfg.Error.NoVerbose = true
+				cfg.Error.VerboseSuffix = "test-suffix"
+				return cfg
 			},
 		},
 		{
-			name: "ultimate",
-			cfg: `
+			name:        "default yaml config with masking rules",
+			cfgDataType: config.DataTypeYAML,
+			cfgData: `
 log:
   masking:
     enabled: true
-    useDefaultRules: false
     rules:
       - field: "api_key"
         formats: ["http_header", "json", "urlencoded"]
         masks:
           - regexp: "<api_key>.+?</api_key>"
-            mask: "<api_key>***</api_key>"`,
-			masking: MaskingConfig{
-				Enabled: true, UseDefaultRules: false, Rules: []MaskingRuleConfig{
+            mask: "<api_key>***</api_key>"
+`,
+			expectedCfg: func() *Config {
+				cfg := NewDefaultConfig()
+				cfg.Masking.Enabled = true
+				cfg.Masking.Rules = []MaskingRuleConfig{
 					{
 						Field:   "api_key",
 						Formats: []FieldMaskFormat{FieldMaskFormatHTTPHeader, FieldMaskFormatJSON, FieldMaskFormatURLEncoded},
-						Masks:   []MaskConfig{{RegExp: "<api_key>.+?</api_key>", Mask: "<api_key>***</api_key>"}},
+						Masks: []MaskConfig{
+							{
+								RegExp: "<api_key>.+?</api_key>",
+								Mask:   "<api_key>***</api_key>",
+							},
+						},
 					},
-				},
+				}
+				return cfg
 			},
 		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			cfg := Config{}
-			err := config.NewDefaultLoader("").LoadFromReader(bytes.NewBuffer([]byte(tc.cfg)), config.DataTypeYAML, &cfg)
+		{
+			name:        "json config",
+			cfgDataType: config.DataTypeJSON,
+			cfgData: `
+{
+	"log": {
+		"level": "error",
+		"format": "text",
+		"output": "file",
+		"file": {
+			"path": "my-service.log",
+			"rotation": {
+				"compress": true,
+				"maxSize": "100M",
+				"maxBackups": 42
+			}
+		},
+		"addCaller": true,
+		"error": {
+			"noVerbose": true,
+			"verboseSuffix": "test-suffix"
+		}
+	}
+}`,
+			expectedCfg: func() *Config {
+				cfg := NewDefaultConfig()
+				cfg.Level = LevelError
+				cfg.Format = FormatText
+				cfg.Output = OutputFile
+				cfg.File.Path = "my-service.log"
+				cfg.File.Rotation.MaxSize = 100 * 1024 * 1024
+				cfg.File.Rotation.MaxBackups = 42
+				cfg.File.Rotation.Compress = true
+				cfg.AddCaller = true
+				cfg.Error.NoVerbose = true
+				cfg.Error.VerboseSuffix = "test-suffix"
+				return cfg
+			},
+		},
+		{
+			name:        "default json config with masking rules",
+			cfgDataType: config.DataTypeJSON,
+			cfgData: `
+{
+	"log": {
+		"masking": {
+			"enabled": true,
+			"rules": [
+				{
+					"field": "api_key",
+					"formats": ["http_header", "json", "urlencoded"],
+					"masks": [
+						{
+							"regexp": "<api_key>.+?</api_key>",
+							"mask": "<api_key>***</api_key>"
+						}
+					]
+				}
+			]
+		}
+	}
+}`,
+			expectedCfg: func() *Config {
+				cfg := NewDefaultConfig()
+				cfg.Masking.Enabled = true
+				cfg.Masking.Rules = []MaskingRuleConfig{
+					{
+						Field:   "api_key",
+						Formats: []FieldMaskFormat{FieldMaskFormatHTTPHeader, FieldMaskFormatJSON, FieldMaskFormatURLEncoded},
+						Masks: []MaskConfig{
+							{
+								RegExp: "<api_key>.+?</api_key>",
+								Mask:   "<api_key>***</api_key>",
+							},
+						},
+					},
+				}
+				return cfg
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Load config using config.Loader.
+			appCfg := AppConfig{Log: NewDefaultConfig()}
+			expectedAppCfg := AppConfig{Log: tt.expectedCfg()}
+			cfgLoader := config.NewLoader(config.NewViperAdapter())
+			err := cfgLoader.LoadFromReader(bytes.NewBuffer([]byte(tt.cfgData)), tt.cfgDataType, appCfg.Log)
 			require.NoError(t, err)
-			require.Equal(t, tc.masking, cfg.Masking)
+			require.Equal(t, expectedAppCfg, appCfg)
+
+			// Load config using viper unmarshal.
+			appCfg = AppConfig{Log: NewDefaultConfig()}
+			expectedAppCfg = AppConfig{Log: tt.expectedCfg()}
+			vpr := viper.New()
+			vpr.SetConfigType(string(tt.cfgDataType))
+			require.NoError(t, vpr.ReadConfig(bytes.NewBuffer([]byte(tt.cfgData))))
+			require.NoError(t, vpr.Unmarshal(&appCfg, func(c *mapstructure.DecoderConfig) {
+				c.DecodeHook = mapstructure.TextUnmarshallerHookFunc()
+			}))
+			require.Equal(t, expectedAppCfg, appCfg)
+
+			// Load config using yaml/json unmarshal.
+			appCfg = AppConfig{Log: NewDefaultConfig()}
+			expectedAppCfg = AppConfig{Log: tt.expectedCfg()}
+			switch tt.cfgDataType {
+			case config.DataTypeYAML:
+				require.NoError(t, yaml.Unmarshal([]byte(tt.cfgData), &appCfg))
+				require.Equal(t, expectedAppCfg, appCfg)
+			case config.DataTypeJSON:
+				require.NoError(t, json.Unmarshal([]byte(tt.cfgData), &appCfg))
+				require.Equal(t, expectedAppCfg, appCfg)
+			default:
+				t.Fatalf("unsupported config data type: %s", tt.cfgDataType)
+			}
+		})
+	}
+}
+
+func TestNewDefaultConfig(t *testing.T) {
+	var cfg *Config
+
+	// Empty config, all defaults for the data provider should be used
+	cfg = NewConfig()
+	require.NoError(t, config.NewDefaultLoader("").LoadFromReader(bytes.NewBuffer(nil), config.DataTypeYAML, cfg))
+	require.Equal(t, NewDefaultConfig(), cfg)
+
+	// viper.Unmarshal
+	cfg = NewDefaultConfig()
+	vpr := viper.New()
+	vpr.SetConfigType("yaml")
+	require.NoError(t, vpr.Unmarshal(&cfg))
+	require.Equal(t, NewDefaultConfig(), cfg)
+
+	// yaml.Unmarshal
+	cfg = NewDefaultConfig()
+	require.NoError(t, yaml.Unmarshal([]byte(""), &cfg))
+	require.Equal(t, NewDefaultConfig(), cfg)
+
+	// json.Unmarshal
+	cfg = NewDefaultConfig()
+	require.NoError(t, json.Unmarshal([]byte("{}"), &cfg))
+	require.Equal(t, NewDefaultConfig(), cfg)
+}
+
+func TestConfigWithKeyPrefix(t *testing.T) {
+	t.Run("custom key prefix", func(t *testing.T) {
+		cfgData := `
+customLog:
+  level: debug
+  format: text
+`
+		expectedCfg := NewDefaultConfig(WithKeyPrefix("customLog"))
+		expectedCfg.Level = LevelDebug
+		expectedCfg.Format = FormatText
+
+		cfg := NewConfig(WithKeyPrefix("customLog"))
+		err := config.NewDefaultLoader("").LoadFromReader(bytes.NewBuffer([]byte(cfgData)), config.DataTypeYAML, cfg)
+		require.NoError(t, err)
+		require.Equal(t, expectedCfg, cfg)
+	})
+
+	t.Run("default key prefix, empty struct initialization", func(t *testing.T) {
+		cfgData := `
+log:
+  level: debug
+  format: text
+`
+		cfg := &Config{}
+		err := config.NewDefaultLoader("").LoadFromReader(bytes.NewBuffer([]byte(cfgData)), config.DataTypeYAML, cfg)
+		require.NoError(t, err)
+		require.Equal(t, LevelDebug, cfg.Level)
+		require.Equal(t, FormatText, cfg.Format)
+	})
+}
+
+func TestConfigValidationErrors(t *testing.T) {
+	tests := []struct {
+		name           string
+		yamlData       string
+		expectedErrMsg string
+	}{
+		{
+			name: "error, unknown log level",
+			yamlData: `
+log:
+  level: invalid-level
+`,
+			expectedErrMsg: `log.level: unknown value "invalid-level", should be one of [error warn info debug]`,
+		},
+		{
+			name: "error, unknown log format",
+			yamlData: `
+log:
+  format: invalid-format
+`,
+			expectedErrMsg: `log.format: unknown value "invalid-format", should be one of [json text]`,
+		},
+		{
+			name: "error, unknown log output",
+			yamlData: `
+log:
+  output: invalid-output
+`,
+			expectedErrMsg: `log.output: unknown value "invalid-output", should be one of [stdout stderr file]`,
+		},
+		{
+			name: "error, file output without path",
+			yamlData: `
+log:
+  output: file
+`,
+			expectedErrMsg: `log.file.path: cannot be empty when "file" output is used`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := NewConfig()
+			err := config.NewDefaultLoader("").LoadFromReader(bytes.NewBuffer([]byte(tt.yamlData)), config.DataTypeYAML, cfg)
+			require.EqualError(t, err, tt.expectedErrMsg)
 		})
 	}
 }

--- a/log/logger.go
+++ b/log/logger.go
@@ -250,10 +250,10 @@ func makeLogfAppenderWithWriter(cfg *Config, w io.Writer) logf.Appender {
 	timeEncoder := logf.RFC3339NanoTimeEncoder
 
 	var errorEncoder logf.ErrorEncoder
-	if cfg.ErrorVerboseSuffix != "" || cfg.ErrorNoVerbose {
+	if cfg.Error.VerboseSuffix != "" || cfg.Error.NoVerbose {
 		errorEncoder = logf.NewErrorEncoder(logf.ErrorEncoderConfig{
-			NoVerboseField:     cfg.ErrorNoVerbose,
-			VerboseFieldSuffix: cfg.ErrorVerboseSuffix,
+			NoVerboseField:     cfg.Error.NoVerbose,
+			VerboseFieldSuffix: cfg.Error.VerboseSuffix,
 		})
 	}
 

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -69,7 +69,13 @@ func TestLoggerToStd(t *testing.T) {
 		}
 
 		go func() {
-			logger, closer := NewLogger(&Config{Output: test.Output, NoColor: true, Format: FormatJSON, Level: LevelInfo, ErrorVerboseSuffix: "err"})
+			logger, closer := NewLogger(&Config{
+				Output:  test.Output,
+				NoColor: true,
+				Format:  FormatJSON,
+				Level:   LevelInfo,
+				Error:   ErrorConfig{VerboseSuffix: "err"}},
+			)
 			switch test.Level {
 			case LevelInfo:
 				logger.Info(test.Msg)
@@ -108,7 +114,13 @@ func TestTextFormat(t *testing.T) {
 	}()
 
 	go func() {
-		logger, closer := NewLogger(&Config{Output: OutputStderr, NoColor: true, Format: FormatText, Level: LevelInfo, ErrorVerboseSuffix: "err"})
+		logger, closer := NewLogger(&Config{
+			Output:  OutputStderr,
+			NoColor: true,
+			Format:  FormatText,
+			Level:   LevelInfo,
+			Error:   ErrorConfig{VerboseSuffix: "err"},
+		})
 		logger.AtLevel(LevelError, func(logFunc LogFunc) {
 			logFunc("test", logf.Error(errors.New("some error")))
 		})

--- a/log/masking_logger_test.go
+++ b/log/masking_logger_test.go
@@ -99,7 +99,12 @@ var logFile = "output.log"
 
 func BenchmarkMaskingLogger(b *testing.B) {
 	defaultLogger, closer := log.NewLogger(&log.Config{
-		Output: log.OutputFile, Format: log.FormatJSON, Level: log.LevelInfo, ErrorVerboseSuffix: "_verbose", AddCaller: true, File: log.FileOutputConfig{
+		Output:    log.OutputFile,
+		Format:    log.FormatJSON,
+		Level:     log.LevelInfo,
+		Error:     log.ErrorConfig{VerboseSuffix: "_verbose"},
+		AddCaller: true,
+		File: log.FileOutputConfig{
 			Path: logFile,
 			Rotation: log.FileRotationConfig{
 				MaxSize: 2 << 30,

--- a/profserver/config.go
+++ b/profserver/config.go
@@ -6,17 +6,27 @@ Released under MIT license.
 
 package profserver
 
-import "github.com/acronis/go-appkit/config"
+import (
+	"fmt"
 
-const (
-	cfgKeyProfServerEnabled = "profserver.enabled"
-	cfgKeyProfServerAddress = "profserver.address"
+	"github.com/acronis/go-appkit/config"
 )
 
+const cfgDefaultKeyPrefix = "profServer"
+
+const (
+	cfgKeyProfServerEnabled = "enabled"
+	cfgKeyProfServerAddress = "address"
+)
+
+const defaultServerAddress = "127.0.0.1:8081"
+
 // Config represents a set of configuration parameters for profiling server.
+// Configuration can be loaded in different formats (YAML, JSON) using config.Loader, viper,
+// or with json.Unmarshal/yaml.Unmarshal functions directly.
 type Config struct {
-	Enabled bool
-	Address string
+	Enabled bool   `mapstructure:"enabled" yaml:"enabled" json:"enabled"`
+	Address string `mapstructure:"address" yaml:"address" json:"address"`
 
 	keyPrefix string
 }
@@ -24,29 +34,72 @@ type Config struct {
 var _ config.Config = (*Config)(nil)
 var _ config.KeyPrefixProvider = (*Config)(nil)
 
-// NewConfig creates a new instance of the Config.
-func NewConfig() *Config {
-	return NewConfigWithKeyPrefix("")
+// ConfigOption is a type for functional options for the Config.
+type ConfigOption func(*configOptions)
+
+type configOptions struct {
+	keyPrefix string
 }
 
-// NewConfigWithKeyPrefix creates a new instance of the Config.
-// Allows specifying key prefix which will be used for parsing configuration parameters.
+// WithKeyPrefix returns a ConfigOption that sets a key prefix for parsing configuration parameters.
+// This prefix will be used by config.Loader.
+func WithKeyPrefix(keyPrefix string) ConfigOption {
+	return func(o *configOptions) {
+		o.keyPrefix = keyPrefix
+	}
+}
+
+// NewConfig creates a new instance of the Config.
+func NewConfig(options ...ConfigOption) *Config {
+	opts := configOptions{keyPrefix: cfgDefaultKeyPrefix} // cfgDefaultKeyPrefix is used here for backward compatibility
+	for _, opt := range options {
+		opt(&opts)
+	}
+	return &Config{keyPrefix: opts.keyPrefix}
+}
+
+// NewConfigWithKeyPrefix creates a new instance of the Config with a key prefix.
+// This prefix will be used by config.Loader.
+// Deprecated: use NewConfig with WithKeyPrefix instead.
 func NewConfigWithKeyPrefix(keyPrefix string) *Config {
+	if keyPrefix != "" {
+		keyPrefix += "."
+	}
+	keyPrefix += cfgDefaultKeyPrefix // cfgDefaultKeyPrefix is added here for backward compatibility
 	return &Config{keyPrefix: keyPrefix}
 }
 
+// NewDefaultConfig creates a new instance of the Config with default values.
+func NewDefaultConfig(options ...ConfigOption) *Config {
+	opts := configOptions{keyPrefix: cfgDefaultKeyPrefix}
+	for _, opt := range options {
+		opt(&opts)
+	}
+	return &Config{
+		keyPrefix: opts.keyPrefix,
+		Enabled:   true,
+		Address:   defaultServerAddress,
+	}
+}
+
 // KeyPrefix returns a key prefix with which all configuration parameters should be presented.
+// Implements config.KeyPrefixProvider interface.
 func (c *Config) KeyPrefix() string {
+	if c.keyPrefix == "" {
+		return cfgDefaultKeyPrefix
+	}
 	return c.keyPrefix
 }
 
 // SetProviderDefaults sets default configuration values for profiling server in config.DataProvider.
+// Implements config.Config interface.
 func (c *Config) SetProviderDefaults(dp config.DataProvider) {
 	dp.SetDefault(cfgKeyProfServerEnabled, true)
-	dp.SetDefault(cfgKeyProfServerAddress, ":8081")
+	dp.SetDefault(cfgKeyProfServerAddress, defaultServerAddress)
 }
 
 // Set sets profiling server configuration values from config.DataProvider.
+// Implements config.Config interface.
 func (c *Config) Set(dp config.DataProvider) error {
 	var err error
 	if c.Enabled, err = dp.GetBool(cfgKeyProfServerEnabled); err != nil {
@@ -54,6 +107,9 @@ func (c *Config) Set(dp config.DataProvider) error {
 	}
 	if c.Address, err = dp.GetString(cfgKeyProfServerAddress); err != nil {
 		return err
+	}
+	if c.Enabled && c.Address == "" {
+		return dp.WrapKeyErr(cfgKeyProfServerAddress, fmt.Errorf("cannot be empty"))
 	}
 	return nil
 }

--- a/profserver/config_test.go
+++ b/profserver/config_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright © 2024 Acronis International GmbH.
+
+Released under MIT license.
+*/
+
+package profserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/acronis/go-appkit/config"
+)
+
+type AppConfig struct {
+	ProfServer *Config `mapstructure:"profServer" json:"profServer" yaml:"profServer"`
+}
+
+func TestConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfgDataType config.DataType
+		cfgData     string
+		expectedCfg func() *Config
+	}{
+		{
+			name:        "yaml config",
+			cfgDataType: config.DataTypeYAML,
+			cfgData: `
+profServer:
+  enabled: false
+  address: "0.0.0.0:6060"
+`,
+			expectedCfg: func() *Config {
+				cfg := NewDefaultConfig()
+				cfg.Enabled = false
+				cfg.Address = "0.0.0.0:6060"
+				return cfg
+			},
+		},
+		{
+			name:        "json config",
+			cfgDataType: config.DataTypeJSON,
+			cfgData: `
+{
+	"profServer": {
+		"enabled": false,
+		"address": "0.0.0.0:6060"
+	}
+}`,
+			expectedCfg: func() *Config {
+				cfg := NewDefaultConfig()
+				cfg.Enabled = false
+				cfg.Address = "0.0.0.0:6060"
+				return cfg
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Load config using config.Loader.
+			appCfg := AppConfig{ProfServer: NewDefaultConfig()}
+			expectedAppCfg := AppConfig{ProfServer: tt.expectedCfg()}
+			cfgLoader := config.NewLoader(config.NewViperAdapter())
+			err := cfgLoader.LoadFromReader(bytes.NewBuffer([]byte(tt.cfgData)), tt.cfgDataType, appCfg.ProfServer)
+			require.NoError(t, err)
+			require.Equal(t, expectedAppCfg, appCfg)
+
+			// Load config using viper unmarshal.
+			appCfg = AppConfig{ProfServer: NewDefaultConfig()}
+			expectedAppCfg = AppConfig{ProfServer: tt.expectedCfg()}
+			vpr := viper.New()
+			vpr.SetConfigType(string(tt.cfgDataType))
+			require.NoError(t, vpr.ReadConfig(bytes.NewBuffer([]byte(tt.cfgData))))
+			require.NoError(t, vpr.Unmarshal(&appCfg))
+			require.Equal(t, expectedAppCfg, appCfg)
+
+			// Load config using yaml/json unmarshal.
+			appCfg = AppConfig{ProfServer: NewDefaultConfig()}
+			expectedAppCfg = AppConfig{ProfServer: tt.expectedCfg()}
+			switch tt.cfgDataType {
+			case config.DataTypeYAML:
+				require.NoError(t, yaml.Unmarshal([]byte(tt.cfgData), &appCfg))
+				require.Equal(t, expectedAppCfg, appCfg)
+			case config.DataTypeJSON:
+				require.NoError(t, json.Unmarshal([]byte(tt.cfgData), &appCfg))
+				require.Equal(t, expectedAppCfg, appCfg)
+			default:
+				t.Fatalf("unsupported config data type: %s", tt.cfgDataType)
+			}
+		})
+	}
+}
+
+func TestNewDefaultConfig(t *testing.T) {
+	var cfg *Config
+
+	// Empty config, all defaults for the data provider should be used
+	cfg = NewConfig()
+	require.NoError(t, config.NewDefaultLoader("").LoadFromReader(bytes.NewBuffer(nil), config.DataTypeYAML, cfg))
+	require.Equal(t, NewDefaultConfig(), cfg)
+
+	// viper.Unmarshal
+	cfg = NewDefaultConfig()
+	vpr := viper.New()
+	vpr.SetConfigType("yaml")
+	require.NoError(t, vpr.Unmarshal(&cfg))
+	require.Equal(t, NewDefaultConfig(), cfg)
+
+	// yaml.Unmarshal
+	cfg = NewDefaultConfig()
+	require.NoError(t, yaml.Unmarshal([]byte(""), &cfg))
+	require.Equal(t, NewDefaultConfig(), cfg)
+
+	// json.Unmarshal
+	cfg = NewDefaultConfig()
+	require.NoError(t, json.Unmarshal([]byte("{}"), &cfg))
+	require.Equal(t, NewDefaultConfig(), cfg)
+}
+
+func TestWithKeyPrefix(t *testing.T) {
+	cfgData := `
+customProfServer:
+  enabled: true
+  address: "127.0.0.1:7070"
+`
+	expectedCfg := NewDefaultConfig(WithKeyPrefix("customProfServer"))
+	expectedCfg.Enabled = true
+	expectedCfg.Address = "127.0.0.1:7070"
+
+	cfg := NewConfig(WithKeyPrefix("customProfServer"))
+	err := config.NewDefaultLoader("").LoadFromReader(bytes.NewBuffer([]byte(cfgData)), config.DataTypeYAML, cfg)
+	require.NoError(t, err)
+	require.Equal(t, expectedCfg, cfg)
+}
+
+func TestConfigValidationErrors(t *testing.T) {
+	tests := []struct {
+		name           string
+		yamlData       string
+		expectedErrMsg string
+	}{
+		{
+			name: "error, invalid address",
+			yamlData: `
+profServer:
+  address: ""
+`,
+			expectedErrMsg: `profServer.address: cannot be empty`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := NewConfig()
+			err := config.NewDefaultLoader("").LoadFromReader(bytes.NewBuffer([]byte(tt.yamlData)), config.DataTypeYAML, cfg)
+			require.EqualError(t, err, tt.expectedErrMsg)
+		})
+	}
+}

--- a/restapi/routing_test.go
+++ b/restapi/routing_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestParseRoutePath(t *testing.T) {
@@ -340,4 +341,74 @@ func mustParseRoutePath(s string) RoutePath {
 		panic(err)
 	}
 	return rp
+}
+
+func TestMethodsList_UnmarshalText(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected MethodsList
+	}{
+		{input: "GET,POST", expected: MethodsList{"GET", "POST"}},
+		{input: "PUT, DELETE", expected: MethodsList{"PUT", "DELETE"}},
+		{input: "", expected: MethodsList{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			var ml MethodsList
+			err := ml.UnmarshalText([]byte(tt.input))
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, ml)
+		})
+	}
+}
+
+func TestMethodsList_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected MethodsList
+		wantErr  bool
+	}{
+		{input: `"GET,POST"`, expected: MethodsList{"GET", "POST"}, wantErr: false},
+		{input: `["PUT", "DELETE"]`, expected: MethodsList{"PUT", "DELETE"}, wantErr: false},
+		{input: `""`, expected: MethodsList{}, wantErr: false},
+		{input: `123`, expected: nil, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			var ml MethodsList
+			err := ml.UnmarshalJSON([]byte(tt.input))
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, ml)
+			}
+		})
+	}
+}
+
+func TestMethodsList_UnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected MethodsList
+		wantErr  bool
+	}{
+		{input: `"GET,POST"`, expected: MethodsList{"GET", "POST"}, wantErr: false},
+		{input: `["PUT", "DELETE"]`, expected: MethodsList{"PUT", "DELETE"}, wantErr: false},
+		{input: `""`, expected: MethodsList{}, wantErr: false},
+		{input: `[123`, expected: nil, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			var ml MethodsList
+			err := yaml.Unmarshal([]byte(tt.input), &ml)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, ml)
+			}
+		})
+	}
 }


### PR DESCRIPTION
This pull request introduces the ability to use standard YAML and JSON unmarshaling mechanisms for loading configurations. The update improves flexibility in configuration management by supporting both direct integer values and human-readable string representations for byte sizes and time durations.

Additionally, configuration management has been enhanced across multiple Go packages, ensuring consistent loading and parsing behavior.

## Changes Introduced
- **New Custom Types**
  - `ByteSize`: A custom type that represents byte sizes, allowing parsing from both raw integers and human-readable formats (e.g., `"10MB"`).
  - `TimeDuration`: A custom type that supports parsing from both nanoseconds-based integers and standard Go duration strings (e.g., `"1s"`, `"500ms"`).

- **Configuration Improvements Across Packages**
  - The following Go packages now support improved configuration loading:
    - `httpserver`
    - `profserver`
    - `httpclient`
    - `httpserver/middleware/throttle`
    - `log`
  - **All configurations in these packages can now be loaded via:**
    - `config.Loader`
    - `Viper`
    - Direct `json.Unmarshal()` / `yaml.Unmarshal()` functions.
  - This ensures a **standardized and flexible approach** for configuration management across the codebase.

## Why This Change?
- **Standardized Configuration Parsing**  
  All configuration values can now be loaded seamlessly using `config.Loader`, `Viper`, or standard unmarshaling functions (`json.Unmarshal()` / `yaml.Unmarshal()`).
- **Improved Usability**  
  The introduction of human-readable formats enhances usability while maintaining compatibility with raw numerical inputs.
- **Better Maintainability**  
  Reducing custom parsing logic ensures consistency and simplifies configuration management across different packages.

## Breaking Changes
- `DefaultClientWaitTimeout` in `httpclient/config.go` has been **renamed to** `DefaultTimeout` and changed from **10s** to **1m**.
- Any direct references to `time.Duration` for configuration values should now use `config.TimeDuration`.
- `config.ViperAdapter.GetSizeInBytes` now returns `ByteSize` instead of `uint64`.