### PR TITLE
Revert recently added config validation rules in httpserver

### DIFF
--- a/httpserver/config.go
+++ b/httpserver/config.go
@@ -211,7 +211,7 @@ func (l *LimitsConfig) Set(dp config.DataProvider) error {
 		return err
 	}
 	if l.MaxRequests < 0 {
-		return dp.WrapKeyErr(cfgKeyServerLimitsMaxRequests, fmt.Errorf("maxRequests must be positive"))
+		return dp.WrapKeyErr(cfgKeyServerLimitsMaxRequests, fmt.Errorf("cannot be negative"))
 	}
 
 	if l.MaxBodySizeBytes, err = dp.GetSizeInBytes(cfgKeyServerLimitsMaxBodySize); err != nil {
@@ -283,10 +283,6 @@ func (s *TLSConfig) Set(dp config.DataProvider) error {
 		return err
 	}
 
-	if s.Enabled && (s.Certificate == "" || s.Key == "") {
-		return dp.WrapKeyErr(cfgKeyServerTLSKey, fmt.Errorf("both cert and key should be set"))
-	}
-
 	return nil
 }
 
@@ -299,9 +295,6 @@ func (c *Config) Set(dp config.DataProvider) error {
 	}
 	if c.UnixSocketPath, err = dp.GetString(cfgKeyServerUnixSocketPath); err != nil {
 		return err
-	}
-	if c.Address == "" && c.UnixSocketPath == "" {
-		return dp.WrapKeyErr(cfgKeyServerAddress, fmt.Errorf("either address or unixSocketPath should be set"))
 	}
 
 	err = c.TLS.Set(dp)

--- a/httpserver/config_test.go
+++ b/httpserver/config_test.go
@@ -217,16 +217,16 @@ func TestConfigValidationErrors(t *testing.T) {
 			name: "error, invalid address",
 			yamlData: `
 server:
-  address: ""
+  address: []
 `,
-			expectedErrMsg: `server.address: either address or unixSocketPath should be set`,
+			expectedErrMsg: `server.address: unable to cast`,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := NewConfig()
 			err := config.NewLoader(config.NewViperAdapter()).LoadFromReader(bytes.NewBuffer([]byte(tt.yamlData)), config.DataTypeYAML, cfg)
-			require.EqualError(t, err, tt.expectedErrMsg)
+			require.ErrorContains(t, err, tt.expectedErrMsg)
 		})
 	}
 }


### PR DESCRIPTION
Those changes were not backward compatible.