### PR TITLE
fix(httpserver): resolve race condition in server shutdown and improve error handling

### DIFF
--- a/httpserver/http_server_test.go
+++ b/httpserver/http_server_test.go
@@ -157,7 +157,7 @@ func TestHTTPServer_StartWithDynamicPort(t *testing.T) {
 }
 
 func TestHTTPServer_Start_UnixSocket(t *testing.T) {
-	testHTTPServerStart(t, "", 0, t.TempDir()+"/s.sock")
+	testHTTPServerStart(t, "", 0, filepath.Join(t.TempDir(), "s.sock"))
 }
 
 func testHTTPServerStart(t *testing.T, host string, port int, unixSocketPath string) {

--- a/httpserver/middleware/recovery.go
+++ b/httpserver/middleware/recovery.go
@@ -66,7 +66,7 @@ func (h *recoveryHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 
 			if logger != nil {
 				var logFields []log.Field
-				if h.opts.StackSize != 0 {
+				if h.opts.StackSize > 0 {
 					stack := make([]byte, h.opts.StackSize)
 					stack = stack[:runtime.Stack(stack, false)]
 					logFields = append(logFields, log.Bytes("stack", stack))


### PR DESCRIPTION
- Replace httpServerDone channel with atomic.Value to prevent race conditions
- Fix stack trace condition in recovery middleware
- Use filepath.Join for cross-platform path construction in tests