### PR TITLE
feat: add comprehensive gRPC in-flight limiting interceptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ The project includes the following packages:
 
 + [config](./config) - loading configuration from environment variables, files, and `io.Reader`. YAML and JSON formats are supported out of the box.
 + [grpcserver](./grpcserver) - gRPC server with configuration from YAML/JSON files, built-in interceptors, and observability features.
-+ [grpcserver/interceptor](./grpcserver/interceptor) - collection of gRPC interceptors for logging, metrics collection, panic recovery, request-id tracing, etc.
++ [grpcserver/interceptor](./grpcserver/interceptor) - collection of gRPC interceptors for logging, metrics collection, panic recovery, request-id tracing, rate and in-flight request limiting, etc.
 + [httpclient](./httpclient) - helpers and a set of `http.RoundTripper` implementations for simplifying typical HTTP client operations (e.g. retries, client-side throttling, setting any header for each request, etc.).
 + [httpserver](./httpserver) - configurable HTTP server (wrapper around `http.Server`) that includes graceful shutdown support, panic recovery, metrics collection, and logging.
-+ [httpserver/middleware](./httpserver/middleware) - collection of middlewares for HTTP server (e.g. request logging, metrics collection, panic recovery, in-flight request limiting, rate limiting, request-id tracing, etc.).
++ [httpserver/middleware](./httpserver/middleware) - collection of middlewares for HTTP server (e.g. request logging, metrics collection, panic recovery, rate and in-flight request limiting, request-id tracing, etc.).
 + [httpserver/middleware/throttle](./httpserver/middleware/throttle) - ready-to-use middleware for server-side throttling that can be flexibly configured via JSON or YAML. The package has its own [README](./httpserver/middleware/throttle/README.md), so check it out for more details.
 + [log](./log) - unified interface for structured logging with included configurable adapter for tiny, fast, and memory-efficient (zero-allocation) [logf](https://github.com/ssgreg/logf) logger.
 + [lrucache](./lrucache) - in-memory LRU cache with collecting Prometheus metrics.

--- a/grpcserver/README.md
+++ b/grpcserver/README.md
@@ -49,7 +49,7 @@ func main () {
 
 ## Documentation
 
-- [Interceptors](interceptor/README.md) - Logging, metrics, recovery, and request ID interceptors
+- [Interceptors](interceptor/README.md) - Logging, metrics, recovery, throttling, and request ID interceptors
 - [Echo Service Example](examples/echo-service/README.md) - Complete working example with testing instructions
 
 ## Configuration

--- a/grpcserver/interceptor/in_flight_limit_interceptor.go
+++ b/grpcserver/interceptor/in_flight_limit_interceptor.go
@@ -1,0 +1,513 @@
+/*
+Copyright © 2025 Acronis International GmbH.
+
+Released under MIT license.
+*/
+
+package interceptor
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strconv"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/acronis/go-appkit/internal/inflightlimit"
+	"github.com/acronis/go-appkit/log"
+)
+
+// DefaultInFlightLimitMaxKeys is a default value of maximum keys number for the InFlightLimit interceptor.
+const DefaultInFlightLimitMaxKeys = 10000
+
+// InFlightLimitLogFieldKey is the name of the logged field that contains a key for the in-flight limiting.
+const InFlightLimitLogFieldKey = "in_flight_limit_key"
+
+// InFlightLimitLogFieldBacklogged is the name of the logged field that indicates if the request was backlogged.
+const InFlightLimitLogFieldBacklogged = "in_flight_limit_backlogged"
+
+// InFlightLimitParams contains data that relates to the in-flight limiting procedure
+// and could be used for rejecting or handling an occurred error.
+type InFlightLimitParams struct {
+	UnaryGetRetryAfter  InFlightLimitUnaryGetRetryAfterFunc
+	StreamGetRetryAfter InFlightLimitStreamGetRetryAfterFunc
+	Key                 string
+	RequestBacklogged   bool
+}
+
+// InFlightLimitUnaryGetKeyFunc is a function that is called for getting key for in-flight limiting in unary requests.
+type InFlightLimitUnaryGetKeyFunc func(ctx context.Context, req interface{},
+	info *grpc.UnaryServerInfo) (key string, bypass bool, err error)
+
+// InFlightLimitStreamGetKeyFunc is a function that is called for getting key for in-flight limiting in stream requests.
+type InFlightLimitStreamGetKeyFunc func(srv interface{}, ss grpc.ServerStream,
+	info *grpc.StreamServerInfo) (key string, bypass bool, err error)
+
+// InFlightLimitUnaryOnRejectFunc is a function that is called for rejecting gRPC unary request when the in-flight limit is exceeded.
+type InFlightLimitUnaryOnRejectFunc func(ctx context.Context, req interface{},
+	info *grpc.UnaryServerInfo, handler grpc.UnaryHandler, params InFlightLimitParams) (interface{}, error)
+
+// InFlightLimitStreamOnRejectFunc is a function that is called for rejecting gRPC stream request when the in-flight limit is exceeded.
+type InFlightLimitStreamOnRejectFunc func(srv interface{}, ss grpc.ServerStream,
+	info *grpc.StreamServerInfo, handler grpc.StreamHandler, params InFlightLimitParams) error
+
+// InFlightLimitUnaryOnErrorFunc is a function that is called when an error occurs during in-flight limiting in unary requests.
+type InFlightLimitUnaryOnErrorFunc func(ctx context.Context, req interface{},
+	info *grpc.UnaryServerInfo, handler grpc.UnaryHandler, params InFlightLimitParams, err error) (interface{}, error)
+
+// InFlightLimitStreamOnErrorFunc is a function that is called when an error occurs during in-flight limiting in stream requests.
+type InFlightLimitStreamOnErrorFunc func(srv interface{}, ss grpc.ServerStream,
+	info *grpc.StreamServerInfo, handler grpc.StreamHandler, params InFlightLimitParams, err error) error
+
+// InFlightLimitUnaryGetRetryAfterFunc is a function that is called to get a value for retry-after header
+// when the in-flight limit is exceeded in unary requests.
+type InFlightLimitUnaryGetRetryAfterFunc func(ctx context.Context, req interface{},
+	info *grpc.UnaryServerInfo) time.Duration
+
+// InFlightLimitStreamGetRetryAfterFunc is a function that is called to get a value for retry-after header
+// when the in-flight limit is exceeded in stream requests.
+type InFlightLimitStreamGetRetryAfterFunc func(srv interface{}, ss grpc.ServerStream,
+	info *grpc.StreamServerInfo) time.Duration
+
+// InFlightLimitOption represents a configuration option for the in-flight limit interceptor.
+type InFlightLimitOption func(*inFlightLimitOptions)
+
+type inFlightLimitOptions struct {
+	unaryGetKey            InFlightLimitUnaryGetKeyFunc
+	streamGetKey           InFlightLimitStreamGetKeyFunc
+	maxKeys                int
+	dryRun                 bool
+	backlogLimit           int
+	backlogTimeout         time.Duration
+	unaryOnReject          InFlightLimitUnaryOnRejectFunc
+	streamOnReject         InFlightLimitStreamOnRejectFunc
+	unaryOnRejectInDryRun  InFlightLimitUnaryOnRejectFunc
+	streamOnRejectInDryRun InFlightLimitStreamOnRejectFunc
+	unaryOnError           InFlightLimitUnaryOnErrorFunc
+	streamOnError          InFlightLimitStreamOnErrorFunc
+	unaryGetRetryAfter     InFlightLimitUnaryGetRetryAfterFunc
+	streamGetRetryAfter    InFlightLimitStreamGetRetryAfterFunc
+}
+
+// WithInFlightLimitUnaryGetKey sets the function to extract in-flight limiting key from unary gRPC requests.
+func WithInFlightLimitUnaryGetKey(getKey InFlightLimitUnaryGetKeyFunc) InFlightLimitOption {
+	return func(opts *inFlightLimitOptions) {
+		opts.unaryGetKey = getKey
+	}
+}
+
+// WithInFlightLimitStreamGetKey sets the function to extract in-flight limiting key from stream gRPC requests.
+func WithInFlightLimitStreamGetKey(getKey InFlightLimitStreamGetKeyFunc) InFlightLimitOption {
+	return func(opts *inFlightLimitOptions) {
+		opts.streamGetKey = getKey
+	}
+}
+
+// WithInFlightLimitMaxKeys sets the maximum number of keys to track.
+func WithInFlightLimitMaxKeys(maxKeys int) InFlightLimitOption {
+	return func(opts *inFlightLimitOptions) {
+		opts.maxKeys = maxKeys
+	}
+}
+
+// WithInFlightLimitDryRun enables dry run mode where limits are checked but not enforced.
+func WithInFlightLimitDryRun(dryRun bool) InFlightLimitOption {
+	return func(opts *inFlightLimitOptions) {
+		opts.dryRun = dryRun
+	}
+}
+
+// WithInFlightLimitBacklogLimit sets the backlog limit for queuing requests.
+func WithInFlightLimitBacklogLimit(backlogLimit int) InFlightLimitOption {
+	return func(opts *inFlightLimitOptions) {
+		opts.backlogLimit = backlogLimit
+	}
+}
+
+// WithInFlightLimitBacklogTimeout sets the timeout for backlogged requests.
+func WithInFlightLimitBacklogTimeout(backlogTimeout time.Duration) InFlightLimitOption {
+	return func(opts *inFlightLimitOptions) {
+		opts.backlogTimeout = backlogTimeout
+	}
+}
+
+// WithInFlightLimitUnaryOnReject sets the callback for handling rejected unary requests.
+func WithInFlightLimitUnaryOnReject(onReject InFlightLimitUnaryOnRejectFunc) InFlightLimitOption {
+	return func(opts *inFlightLimitOptions) {
+		opts.unaryOnReject = onReject
+	}
+}
+
+// WithInFlightLimitStreamOnReject sets the callback for handling rejected stream requests.
+func WithInFlightLimitStreamOnReject(onReject InFlightLimitStreamOnRejectFunc) InFlightLimitOption {
+	return func(opts *inFlightLimitOptions) {
+		opts.streamOnReject = onReject
+	}
+}
+
+// WithInFlightLimitUnaryOnRejectInDryRun sets the callback for handling rejected unary requests in dry run mode.
+func WithInFlightLimitUnaryOnRejectInDryRun(onReject InFlightLimitUnaryOnRejectFunc) InFlightLimitOption {
+	return func(opts *inFlightLimitOptions) {
+		opts.unaryOnRejectInDryRun = onReject
+	}
+}
+
+// WithInFlightLimitStreamOnRejectInDryRun sets the callback for handling rejected stream requests in dry run mode.
+func WithInFlightLimitStreamOnRejectInDryRun(onReject InFlightLimitStreamOnRejectFunc) InFlightLimitOption {
+	return func(opts *inFlightLimitOptions) {
+		opts.streamOnRejectInDryRun = onReject
+	}
+}
+
+// WithInFlightLimitUnaryOnError sets the callback for handling in-flight limiting errors in unary requests.
+func WithInFlightLimitUnaryOnError(onError InFlightLimitUnaryOnErrorFunc) InFlightLimitOption {
+	return func(opts *inFlightLimitOptions) {
+		opts.unaryOnError = onError
+	}
+}
+
+// WithInFlightLimitStreamOnError sets the callback for handling in-flight limiting errors in stream requests.
+func WithInFlightLimitStreamOnError(onError InFlightLimitStreamOnErrorFunc) InFlightLimitOption {
+	return func(opts *inFlightLimitOptions) {
+		opts.streamOnError = onError
+	}
+}
+
+// WithInFlightLimitUnaryGetRetryAfter sets the function to calculate retry-after value for unary requests.
+func WithInFlightLimitUnaryGetRetryAfter(getRetryAfter InFlightLimitUnaryGetRetryAfterFunc) InFlightLimitOption {
+	return func(opts *inFlightLimitOptions) {
+		opts.unaryGetRetryAfter = getRetryAfter
+	}
+}
+
+// WithInFlightLimitStreamGetRetryAfter sets the function to calculate retry-after value for stream requests.
+func WithInFlightLimitStreamGetRetryAfter(getRetryAfter InFlightLimitStreamGetRetryAfterFunc) InFlightLimitOption {
+	return func(opts *inFlightLimitOptions) {
+		opts.streamGetRetryAfter = getRetryAfter
+	}
+}
+
+// InFlightLimitUnaryInterceptor is a gRPC unary interceptor that limits the number of in-flight requests.
+func InFlightLimitUnaryInterceptor(limit int, options ...InFlightLimitOption) (func(
+	ctx context.Context,
+	req interface{},
+	info *grpc.UnaryServerInfo,
+	handler grpc.UnaryHandler,
+) (interface{}, error), error) {
+	handler, err := newInFlightLimitHandler(limit, true, options...)
+	if err != nil {
+		return nil, err
+	}
+	return handler.handleUnary, nil
+}
+
+// InFlightLimitStreamInterceptor is a gRPC stream interceptor that limits the number of in-flight requests.
+func InFlightLimitStreamInterceptor(limit int, options ...InFlightLimitOption) (func(
+	srv interface{},
+	ss grpc.ServerStream,
+	info *grpc.StreamServerInfo,
+	handler grpc.StreamHandler,
+) error, error) {
+	handler, err := newInFlightLimitHandler(limit, false, options...)
+	if err != nil {
+		return nil, err
+	}
+	return handler.handleStream, nil
+}
+
+type inFlightLimitHandler struct {
+	processor           *inflightlimit.RequestProcessor
+	unaryGetKey         InFlightLimitUnaryGetKeyFunc
+	streamGetKey        InFlightLimitStreamGetKeyFunc
+	unaryOnReject       InFlightLimitUnaryOnRejectFunc
+	streamOnReject      InFlightLimitStreamOnRejectFunc
+	unaryOnError        InFlightLimitUnaryOnErrorFunc
+	streamOnError       InFlightLimitStreamOnErrorFunc
+	unaryGetRetryAfter  InFlightLimitUnaryGetRetryAfterFunc
+	streamGetRetryAfter InFlightLimitStreamGetRetryAfterFunc
+}
+
+func newInFlightLimitHandler(limit int, isUnary bool, options ...InFlightLimitOption) (*inFlightLimitHandler, error) {
+	opts := &inFlightLimitOptions{
+		backlogTimeout:         inflightlimit.DefaultInFlightLimitBacklogTimeout,
+		unaryOnReject:          DefaultInFlightLimitUnaryOnReject,
+		streamOnReject:         DefaultInFlightLimitStreamOnReject,
+		unaryOnRejectInDryRun:  DefaultInFlightLimitUnaryOnRejectInDryRun,
+		streamOnRejectInDryRun: DefaultInFlightLimitStreamOnRejectInDryRun,
+		unaryOnError:           DefaultInFlightLimitUnaryOnError,
+		streamOnError:          DefaultInFlightLimitStreamOnError,
+	}
+	for _, option := range options {
+		option(opts)
+	}
+
+	maxKeys := 0
+	if (opts.unaryGetKey != nil && isUnary) || (opts.streamGetKey != nil && !isUnary) {
+		maxKeys = opts.maxKeys
+		if maxKeys == 0 {
+			maxKeys = DefaultInFlightLimitMaxKeys
+		}
+	}
+
+	backlogParams := inflightlimit.BacklogParams{
+		MaxKeys: maxKeys,
+		Limit:   opts.backlogLimit,
+		Timeout: opts.backlogTimeout,
+	}
+
+	processor, err := inflightlimit.NewRequestProcessor(limit, backlogParams, opts.dryRun)
+	if err != nil {
+		return nil, fmt.Errorf("create request processor: %w", err)
+	}
+
+	return &inFlightLimitHandler{
+		processor:           processor,
+		unaryGetKey:         opts.unaryGetKey,
+		streamGetKey:        opts.streamGetKey,
+		unaryOnReject:       makeInFlightLimitUnaryOnRejectFunc(opts),
+		streamOnReject:      makeInFlightLimitStreamOnRejectFunc(opts),
+		unaryOnError:        opts.unaryOnError,
+		streamOnError:       opts.streamOnError,
+		unaryGetRetryAfter:  opts.unaryGetRetryAfter,
+		streamGetRetryAfter: opts.streamGetRetryAfter,
+	}, nil
+}
+
+// unaryInFlightLimitRequestHandler implements inflightlimit.RequestHandler for unary gRPC requests.
+type unaryInFlightLimitRequestHandler struct {
+	ctx     context.Context
+	req     interface{}
+	info    *grpc.UnaryServerInfo
+	handler grpc.UnaryHandler
+	parent  *inFlightLimitHandler
+	result  interface{}
+}
+
+func (rh *unaryInFlightLimitRequestHandler) GetContext() context.Context {
+	return rh.ctx
+}
+
+func (rh *unaryInFlightLimitRequestHandler) GetKey() (key string, bypass bool, err error) {
+	if rh.parent.unaryGetKey != nil {
+		return rh.parent.unaryGetKey(rh.ctx, rh.req, rh.info)
+	}
+	return "", false, nil
+}
+
+func (rh *unaryInFlightLimitRequestHandler) Execute() error {
+	var err error
+	rh.result, err = rh.handler(rh.ctx, rh.req)
+	return err
+}
+
+func (rh *unaryInFlightLimitRequestHandler) OnReject(params inflightlimit.Params) error {
+	var handlerErr error
+	rh.result, handlerErr = rh.parent.unaryOnReject(rh.ctx, rh.req, rh.info, rh.handler, rh.convertParams(params))
+	return handlerErr
+}
+
+func (rh *unaryInFlightLimitRequestHandler) OnError(params inflightlimit.Params, err error) error {
+	var handlerErr error
+	rh.result, handlerErr = rh.parent.unaryOnError(rh.ctx, rh.req, rh.info, rh.handler, rh.convertParams(params), err)
+	return handlerErr
+}
+
+func (rh *unaryInFlightLimitRequestHandler) convertParams(params inflightlimit.Params) InFlightLimitParams {
+	return InFlightLimitParams{
+		UnaryGetRetryAfter: rh.parent.unaryGetRetryAfter,
+		Key:                params.Key,
+		RequestBacklogged:  params.RequestBacklogged,
+	}
+}
+
+// streamInFlightLimitRequestHandler implements inflightlimit.RequestHandler for stream gRPC requests.
+type streamInFlightLimitRequestHandler struct {
+	srv     interface{}
+	ss      grpc.ServerStream
+	info    *grpc.StreamServerInfo
+	handler grpc.StreamHandler
+	parent  *inFlightLimitHandler
+}
+
+func (rh *streamInFlightLimitRequestHandler) GetContext() context.Context {
+	return rh.ss.Context()
+}
+
+func (rh *streamInFlightLimitRequestHandler) GetKey() (key string, bypass bool, err error) {
+	if rh.parent.streamGetKey != nil {
+		return rh.parent.streamGetKey(rh.srv, rh.ss, rh.info)
+	}
+	return "", false, nil
+}
+
+func (rh *streamInFlightLimitRequestHandler) Execute() error {
+	return rh.handler(rh.srv, rh.ss)
+}
+
+func (rh *streamInFlightLimitRequestHandler) OnReject(params inflightlimit.Params) error {
+	return rh.parent.streamOnReject(rh.srv, rh.ss, rh.info, rh.handler, rh.convertParams(params))
+}
+
+func (rh *streamInFlightLimitRequestHandler) OnError(params inflightlimit.Params, err error) error {
+	return rh.parent.streamOnError(rh.srv, rh.ss, rh.info, rh.handler, rh.convertParams(params), err)
+}
+
+func (rh *streamInFlightLimitRequestHandler) convertParams(params inflightlimit.Params) InFlightLimitParams {
+	return InFlightLimitParams{
+		StreamGetRetryAfter: rh.parent.streamGetRetryAfter,
+		Key:                 params.Key,
+		RequestBacklogged:   params.RequestBacklogged,
+	}
+}
+
+func (h *inFlightLimitHandler) handleUnary(
+	ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
+) (interface{}, error) {
+	requestHandler := &unaryInFlightLimitRequestHandler{ctx: ctx, req: req, info: info, handler: handler, parent: h}
+	err := h.processor.ProcessRequest(requestHandler)
+	return requestHandler.result, err
+}
+
+func (h *inFlightLimitHandler) handleStream(
+	srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler,
+) error {
+	requestHandler := &streamInFlightLimitRequestHandler{srv: srv, ss: ss, info: info, handler: handler, parent: h}
+	return h.processor.ProcessRequest(requestHandler)
+}
+
+// DefaultInFlightLimitUnaryOnReject sends gRPC error response when the in-flight limit is exceeded for unary requests.
+func DefaultInFlightLimitUnaryOnReject(
+	ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler, params InFlightLimitParams,
+) (interface{}, error) {
+	logger := GetLoggerFromContext(ctx)
+	if logger != nil {
+		logger.Warn("in-flight limit exceeded",
+			log.String(InFlightLimitLogFieldKey, params.Key),
+			log.Bool(InFlightLimitLogFieldBacklogged, params.RequestBacklogged),
+		)
+	}
+
+	// Set retry after header in gRPC metadata if available
+	if params.UnaryGetRetryAfter != nil {
+		retryAfter := params.UnaryGetRetryAfter(ctx, req, info)
+		retryAfterSeconds := int(math.Ceil(retryAfter.Seconds()))
+		md := metadata.Pairs("retry-after", strconv.Itoa(retryAfterSeconds))
+		if err := grpc.SetHeader(ctx, md); err != nil && logger != nil {
+			logger.Warn("failed to set retry-after header", log.Error(err))
+		}
+	}
+
+	return nil, status.Error(codes.ResourceExhausted, "Too many in-flight requests")
+}
+
+// DefaultInFlightLimitStreamOnReject sends gRPC error response when the in-flight limit is exceeded for stream requests.
+func DefaultInFlightLimitStreamOnReject(
+	srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler, params InFlightLimitParams,
+) error {
+	ctx := ss.Context()
+	logger := GetLoggerFromContext(ctx)
+	if logger != nil {
+		logger.Warn("in-flight limit exceeded",
+			log.String(InFlightLimitLogFieldKey, params.Key),
+			log.Bool(InFlightLimitLogFieldBacklogged, params.RequestBacklogged),
+		)
+	}
+
+	// Set retry after header in gRPC metadata if available
+	if params.StreamGetRetryAfter != nil {
+		retryAfter := params.StreamGetRetryAfter(srv, ss, info)
+		retryAfterSeconds := int(math.Ceil(retryAfter.Seconds()))
+		md := metadata.Pairs("retry-after", strconv.Itoa(retryAfterSeconds))
+		if err := ss.SetHeader(md); err != nil && logger != nil {
+			logger.Warn("failed to set retry-after header", log.Error(err))
+		}
+	}
+
+	return status.Error(codes.ResourceExhausted, "Too many in-flight requests")
+}
+
+// defaultInFlightLimitError contains the shared logic for handling in-flight limit errors
+func defaultInFlightLimitError(ctx context.Context, params InFlightLimitParams, err error) error {
+	logger := GetLoggerFromContext(ctx)
+	if logger != nil {
+		logger.Error("in-flight limiting error",
+			log.String(InFlightLimitLogFieldKey, params.Key),
+			log.Error(err),
+		)
+	}
+	return status.Error(codes.Internal, "Internal server error")
+}
+
+// DefaultInFlightLimitUnaryOnError sends gRPC error response when an error occurs during in-flight limiting in unary requests.
+func DefaultInFlightLimitUnaryOnError(
+	ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler, params InFlightLimitParams, err error,
+) (interface{}, error) {
+	handlerErr := defaultInFlightLimitError(ctx, params, err)
+	return nil, handlerErr
+}
+
+// DefaultInFlightLimitStreamOnError sends gRPC error response when an error occurs during in-flight limiting in stream requests.
+func DefaultInFlightLimitStreamOnError(
+	srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler, params InFlightLimitParams, err error,
+) error {
+	return defaultInFlightLimitError(ss.Context(), params, err)
+}
+
+// DefaultInFlightLimitUnaryOnRejectInDryRun continues processing unary requests when in-flight limit is exceeded in dry run mode.
+func DefaultInFlightLimitUnaryOnRejectInDryRun(
+	ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler, params InFlightLimitParams,
+) (interface{}, error) {
+	logger := GetLoggerFromContext(ctx)
+	if logger != nil {
+		logger.Warn("in-flight limit exceeded, continuing in dry run mode",
+			log.String(InFlightLimitLogFieldKey, params.Key),
+			log.Bool(InFlightLimitLogFieldBacklogged, params.RequestBacklogged),
+		)
+	}
+	return handler(ctx, req)
+}
+
+// DefaultInFlightLimitStreamOnRejectInDryRun continues processing stream requests when in-flight limit is exceeded in dry run mode.
+func DefaultInFlightLimitStreamOnRejectInDryRun(
+	srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler, params InFlightLimitParams,
+) error {
+	logger := GetLoggerFromContext(ss.Context())
+	if logger != nil {
+		logger.Warn("in-flight limit exceeded, continuing in dry run mode",
+			log.String(InFlightLimitLogFieldKey, params.Key),
+			log.Bool(InFlightLimitLogFieldBacklogged, params.RequestBacklogged),
+		)
+	}
+	return handler(srv, ss)
+}
+
+func makeInFlightLimitUnaryOnRejectFunc(opts *inFlightLimitOptions) InFlightLimitUnaryOnRejectFunc {
+	if opts.dryRun {
+		if opts.unaryOnRejectInDryRun != nil {
+			return opts.unaryOnRejectInDryRun
+		}
+		return DefaultInFlightLimitUnaryOnRejectInDryRun
+	}
+	if opts.unaryOnReject != nil {
+		return opts.unaryOnReject
+	}
+	return DefaultInFlightLimitUnaryOnReject
+}
+
+func makeInFlightLimitStreamOnRejectFunc(opts *inFlightLimitOptions) InFlightLimitStreamOnRejectFunc {
+	if opts.dryRun {
+		if opts.streamOnRejectInDryRun != nil {
+			return opts.streamOnRejectInDryRun
+		}
+		return DefaultInFlightLimitStreamOnRejectInDryRun
+	}
+	if opts.streamOnReject != nil {
+		return opts.streamOnReject
+	}
+	return DefaultInFlightLimitStreamOnReject
+}

--- a/grpcserver/interceptor/in_flight_limit_interceptor_test.go
+++ b/grpcserver/interceptor/in_flight_limit_interceptor_test.go
@@ -1,0 +1,1311 @@
+/*
+Copyright © 2025 Acronis International GmbH.
+
+Released under MIT license.
+*/
+
+package interceptor
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/atomic"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/interop/grpc_testing"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/acronis/go-appkit/log"
+	"github.com/acronis/go-appkit/log/logtest"
+	"github.com/acronis/go-appkit/testutil"
+)
+
+// InFlightLimitInterceptorTestSuite is a test suite for InFlightLimit interceptors
+type InFlightLimitInterceptorTestSuite struct {
+	suite.Suite
+	IsUnary bool
+}
+
+func TestInFlightLimitUnaryInterceptor(t *testing.T) {
+	suite.Run(t, &InFlightLimitInterceptorTestSuite{IsUnary: true})
+}
+
+func TestInFlightLimitStreamInterceptor(t *testing.T) {
+	suite.Run(t, &InFlightLimitInterceptorTestSuite{IsUnary: false})
+}
+
+func (s *InFlightLimitInterceptorTestSuite) TestInFlightLimitInterceptor_BasicFunctionality() {
+	limit := 1
+	logger := logtest.NewRecorder()
+	svc, client, closeSvc, err := s.setupTestService(logger, limit, nil)
+	s.Require().NoError(err)
+	defer func() { s.Require().NoError(closeSvc()) }()
+
+	// Set up slow handlers to create in-flight requests
+	acquired := make(chan struct{})
+	release := make(chan struct{})
+
+	if s.IsUnary {
+		svc.SwitchUnaryCallHandler(func(ctx context.Context, req *grpc_testing.SimpleRequest) (*grpc_testing.SimpleResponse, error) {
+			acquired <- struct{}{}
+			<-release
+			return &grpc_testing.SimpleResponse{Payload: &grpc_testing.Payload{Body: []byte("test")}}, nil
+		})
+	} else {
+		svc.SwitchStreamingOutputCallHandler(func(req *grpc_testing.StreamingOutputCallRequest, stream grpc_testing.TestService_StreamingOutputCallServer) error {
+			acquired <- struct{}{}
+			<-release
+			return stream.Send(&grpc_testing.StreamingOutputCallResponse{
+				Payload: &grpc_testing.Payload{Body: []byte("test-stream")},
+			})
+		})
+	}
+
+	// Start first request
+	firstCallErr := make(chan error, 1)
+	firstCallDone := make(chan struct{})
+	go func() {
+		defer close(firstCallDone)
+		if s.IsUnary {
+			_, unaryErr := client.UnaryCall(context.Background(), &grpc_testing.SimpleRequest{})
+			if unaryErr != nil {
+				firstCallErr <- unaryErr
+			}
+		} else {
+			stream, streamErr := client.StreamingOutputCall(context.Background(), &grpc_testing.StreamingOutputCallRequest{})
+			if streamErr != nil {
+				firstCallErr <- streamErr
+				return
+			}
+			if _, recvErr := stream.Recv(); recvErr != nil {
+				firstCallErr <- recvErr
+			}
+		}
+	}()
+
+	// Wait for first request to be acquired
+	select {
+	case <-acquired:
+	case <-time.After(5 * time.Second):
+		s.Fail("First request did not acquire in-flight limit slot in time")
+	}
+
+	// Second request should be rejected
+	if s.IsUnary {
+		_, unaryErr := client.UnaryCall(context.Background(), &grpc_testing.SimpleRequest{})
+		s.Require().Error(unaryErr)
+		s.Require().Equal(codes.ResourceExhausted, status.Code(unaryErr))
+	} else {
+		stream, streamErr := client.StreamingOutputCall(context.Background(), &grpc_testing.StreamingOutputCallRequest{})
+		s.Require().NoError(streamErr)
+		_, recvErr := stream.Recv()
+		s.Require().Error(recvErr)
+		s.Require().Equal(codes.ResourceExhausted, status.Code(recvErr))
+	}
+
+	// Release first request
+	close(release)
+
+	// Check that the first call completed successfully
+	select {
+	case <-firstCallDone:
+	case <-time.After(5 * time.Second):
+		s.Fail("First request did not complete in time")
+	}
+	testutil.RequireNoErrorInChannel(s.T(), firstCallErr, 5*time.Second)
+}
+
+func (s *InFlightLimitInterceptorTestSuite) TestInFlightLimitInterceptor_ConcurrentRequests() {
+	limit := 3
+	concurrentReqs := 10
+
+	logger := logtest.NewRecorder()
+	svc, client, closeSvc, err := s.setupTestService(logger, limit, nil)
+	s.Require().NoError(err)
+	defer func() { s.Require().NoError(closeSvc()) }()
+
+	// Set up slow handlers to create in-flight requests
+	s.setupSlowHandlers(svc, 100*time.Millisecond)
+
+	var okCount, rejectedCount, otherErrsCount atomic.Int32
+	var wg sync.WaitGroup
+
+	for i := 0; i < concurrentReqs; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if s.IsUnary {
+				_, unaryErr := client.UnaryCall(context.Background(), &grpc_testing.SimpleRequest{})
+				if unaryErr != nil {
+					if status.Code(unaryErr) == codes.ResourceExhausted {
+						rejectedCount.Inc()
+					} else {
+						otherErrsCount.Inc()
+					}
+				} else {
+					okCount.Inc()
+				}
+			} else {
+				stream, streamErr := client.StreamingOutputCall(context.Background(), &grpc_testing.StreamingOutputCallRequest{})
+				if streamErr != nil {
+					otherErrsCount.Inc()
+					return
+				}
+				_, recvErr := stream.Recv()
+				if recvErr != nil {
+					if status.Code(recvErr) == codes.ResourceExhausted {
+						rejectedCount.Inc()
+					} else {
+						otherErrsCount.Inc()
+					}
+				} else {
+					okCount.Inc()
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Should allow exactly `limit` requests
+	s.Require().Equal(limit, int(okCount.Load()))
+	s.Require().Equal(concurrentReqs-limit, int(rejectedCount.Load()))
+	s.Require().Equal(0, int(otherErrsCount.Load()))
+}
+
+func (s *InFlightLimitInterceptorTestSuite) TestInFlightLimitInterceptor_WithGetKey() {
+	limit := 2
+
+	getUnaryKeyByClientID := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo) (string, bool, error) {
+		if md, ok := metadata.FromIncomingContext(ctx); ok {
+			if clientIDs := md.Get("client-id"); len(clientIDs) > 0 {
+				return clientIDs[0], false, nil
+			}
+		}
+		return "", true, nil // bypass if no client-id
+	}
+
+	getStreamKeyByClientID := func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo) (string, bool, error) {
+		if md, ok := metadata.FromIncomingContext(ss.Context()); ok {
+			if clientIDs := md.Get("client-id"); len(clientIDs) > 0 {
+				return clientIDs[0], false, nil
+			}
+		}
+		return "", true, nil // bypass if no client-id
+	}
+
+	logger := logtest.NewRecorder()
+	svc, client, closeSvc, err := s.setupTestService(logger, limit, []InFlightLimitOption{
+		WithInFlightLimitUnaryGetKey(getUnaryKeyByClientID),
+		WithInFlightLimitStreamGetKey(getStreamKeyByClientID),
+	})
+	s.Require().NoError(err)
+	defer func() { s.Require().NoError(closeSvc()) }()
+
+	// Set up slow handlers to create in-flight requests
+	s.setupSlowHandlers(svc, 100*time.Millisecond)
+
+	// Test with client-1 - should be limited by key
+	client1Ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("client-id", "client-1"))
+
+	var okCount, rejectedCount, otherErrsCount atomic.Int32
+	var wg sync.WaitGroup
+
+	// Launch 5 concurrent requests for client-1 - only 2 should succeed (limit=2)
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if s.IsUnary {
+				_, unaryErr := client.UnaryCall(client1Ctx, &grpc_testing.SimpleRequest{})
+				if unaryErr != nil {
+					if status.Code(unaryErr) == codes.ResourceExhausted {
+						rejectedCount.Inc()
+					} else {
+						otherErrsCount.Inc()
+					}
+				} else {
+					okCount.Inc()
+				}
+			} else {
+				stream, streamErr := client.StreamingOutputCall(client1Ctx, &grpc_testing.StreamingOutputCallRequest{})
+				if streamErr != nil {
+					otherErrsCount.Inc()
+				}
+				_, recvErr := stream.Recv()
+				if recvErr != nil {
+					if status.Code(recvErr) == codes.ResourceExhausted {
+						rejectedCount.Inc()
+					} else {
+						otherErrsCount.Inc()
+					}
+				} else {
+					okCount.Inc()
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Should have exactly limit successful requests and the rest rejected
+	s.Require().Equal(limit, int(okCount.Load()))
+	s.Require().Equal(5-limit, int(rejectedCount.Load()))
+	s.Require().Equal(0, int(otherErrsCount.Load()))
+
+	// Client-2 should have its own separate in-flight limit
+	client2Ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("client-id", "client-2"))
+	if s.IsUnary {
+		_, err = client.UnaryCall(client2Ctx, &grpc_testing.SimpleRequest{})
+		s.Require().NoError(err)
+	} else {
+		stream, streamErr := client.StreamingOutputCall(client2Ctx, &grpc_testing.StreamingOutputCallRequest{})
+		s.Require().NoError(streamErr)
+		_, recvErr := stream.Recv()
+		s.Require().NoError(recvErr)
+	}
+
+	// Request without client-id should bypass in-flight limiting
+	if s.IsUnary {
+		_, err = client.UnaryCall(context.Background(), &grpc_testing.SimpleRequest{})
+		s.Require().NoError(err)
+		_, err = client.UnaryCall(context.Background(), &grpc_testing.SimpleRequest{})
+		s.Require().NoError(err)
+	} else {
+		stream, streamErr := client.StreamingOutputCall(context.Background(), &grpc_testing.StreamingOutputCallRequest{})
+		s.Require().NoError(streamErr)
+		_, recvErr := stream.Recv()
+		s.Require().NoError(recvErr)
+
+		stream2, streamErr2 := client.StreamingOutputCall(context.Background(), &grpc_testing.StreamingOutputCallRequest{})
+		s.Require().NoError(streamErr2)
+		_, recvErr2 := stream2.Recv()
+		s.Require().NoError(recvErr2)
+	}
+}
+
+func (s *InFlightLimitInterceptorTestSuite) TestInFlightLimitInterceptor_DryRun() {
+	limit := 1
+
+	logger := logtest.NewRecorder()
+	svc, client, closeSvc, err := s.setupTestService(logger, limit, []InFlightLimitOption{
+		WithInFlightLimitDryRun(true),
+	})
+	s.Require().NoError(err)
+	defer func() { s.Require().NoError(closeSvc()) }()
+
+	// Set up slow handlers to create in-flight requests
+	s.setupSlowHandlers(svc, 100*time.Millisecond)
+
+	reqCtx := context.Background()
+
+	// All requests should succeed in dry run mode
+	concurrentReqs := 5
+	var okCount atomic.Int32
+	var wg sync.WaitGroup
+
+	for i := 0; i < concurrentReqs; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if s.IsUnary {
+				_, unaryErr := client.UnaryCall(reqCtx, &grpc_testing.SimpleRequest{})
+				if unaryErr == nil {
+					okCount.Inc()
+				}
+			} else {
+				stream, streamErr := client.StreamingOutputCall(reqCtx, &grpc_testing.StreamingOutputCallRequest{})
+				if streamErr == nil {
+					_, recvErr := stream.Recv()
+					if recvErr == nil {
+						okCount.Inc()
+					}
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	// All requests should succeed
+	s.Require().Equal(concurrentReqs, int(okCount.Load()))
+
+	// Should have warning logs about in-flight limit being exceeded
+	s.Require().Greater(len(logger.Entries()), 0)
+	foundWarning := false
+	for _, entry := range logger.Entries() {
+		if entry.Level == log.LevelWarn && entry.Text == "in-flight limit exceeded, continuing in dry run mode" {
+			foundWarning = true
+			break
+		}
+	}
+	s.Require().True(foundWarning)
+}
+
+func (s *InFlightLimitInterceptorTestSuite) TestInFlightLimitInterceptor_Backlog() {
+	limit := 1
+	backlogLimit := 1
+
+	logger := logtest.NewRecorder()
+	svc, client, closeSvc, err := s.setupTestService(logger, limit, []InFlightLimitOption{
+		WithInFlightLimitBacklogLimit(backlogLimit),
+		WithInFlightLimitBacklogTimeout(time.Second),
+	})
+	s.Require().NoError(err)
+	defer func() { s.Require().NoError(closeSvc()) }()
+
+	// Set up slow handlers to create in-flight requests
+	s.setupSlowHandlers(svc, 200*time.Millisecond)
+
+	reqCtx := context.Background()
+
+	// Start first request - it will take 200ms to complete
+	firstCallErr := make(chan error, 1)
+	firstCallDone := make(chan struct{})
+	go func() {
+		defer close(firstCallDone)
+		if s.IsUnary {
+			_, unaryErr := client.UnaryCall(reqCtx, &grpc_testing.SimpleRequest{})
+			if unaryErr != nil {
+				firstCallErr <- unaryErr
+			}
+		} else {
+			stream, streamErr := client.StreamingOutputCall(reqCtx, &grpc_testing.StreamingOutputCallRequest{})
+			if streamErr != nil {
+				firstCallErr <- streamErr
+				return
+			}
+			if _, recvErr := stream.Recv(); recvErr != nil {
+				firstCallErr <- recvErr
+			}
+		}
+	}()
+
+	// Give the first request time to start
+	time.Sleep(50 * time.Millisecond)
+
+	// Second request should be backlogged and eventually succeed
+	startTime := time.Now()
+	if s.IsUnary {
+		_, unaryErr := client.UnaryCall(reqCtx, &grpc_testing.SimpleRequest{})
+		s.Require().NoError(unaryErr)
+	} else {
+		stream, streamErr := client.StreamingOutputCall(reqCtx, &grpc_testing.StreamingOutputCallRequest{})
+		s.Require().NoError(streamErr)
+		_, recvErr := stream.Recv()
+		s.Require().NoError(recvErr)
+	}
+	duration := time.Since(startTime)
+
+	// Should have waited at least 150ms (200ms - 50ms already elapsed)
+	s.Require().GreaterOrEqual(duration, 100*time.Millisecond)
+
+	// Check that the first call completed successfully
+	select {
+	case <-firstCallDone:
+	case <-time.After(5 * time.Second):
+		s.Fail("First request did not complete in time")
+	}
+	testutil.RequireNoErrorInChannel(s.T(), firstCallErr, 5*time.Second)
+}
+
+func (s *InFlightLimitInterceptorTestSuite) TestInFlightLimitInterceptor_BacklogTimeout() {
+	limit := 1
+	backlogTimeout := 100 * time.Millisecond
+
+	logger := logtest.NewRecorder()
+	svc, client, closeSvc, err := s.setupTestService(logger, limit, []InFlightLimitOption{
+		WithInFlightLimitBacklogLimit(1),
+		WithInFlightLimitBacklogTimeout(backlogTimeout),
+	})
+	s.Require().NoError(err)
+	defer func() { s.Require().NoError(closeSvc()) }()
+
+	// Set up very slow handlers to create in-flight requests
+	acquired := make(chan struct{})
+	release := make(chan struct{})
+
+	if s.IsUnary {
+		svc.SwitchUnaryCallHandler(func(ctx context.Context, req *grpc_testing.SimpleRequest) (*grpc_testing.SimpleResponse, error) {
+			acquired <- struct{}{}
+			<-release
+			return &grpc_testing.SimpleResponse{Payload: &grpc_testing.Payload{Body: []byte("test")}}, nil
+		})
+	} else {
+		svc.SwitchStreamingOutputCallHandler(func(req *grpc_testing.StreamingOutputCallRequest, stream grpc_testing.TestService_StreamingOutputCallServer) error {
+			acquired <- struct{}{}
+			<-release
+			return stream.Send(&grpc_testing.StreamingOutputCallResponse{
+				Payload: &grpc_testing.Payload{Body: []byte("test-stream")},
+			})
+		})
+	}
+
+	reqCtx := context.Background()
+
+	// Start first request
+	firstCallErr := make(chan error, 1)
+	firstCallDone := make(chan struct{})
+	go func() {
+		defer close(firstCallDone)
+		if s.IsUnary {
+			_, unaryErr := client.UnaryCall(reqCtx, &grpc_testing.SimpleRequest{})
+			if unaryErr != nil {
+				firstCallErr <- unaryErr
+			}
+		} else {
+			stream, streamErr := client.StreamingOutputCall(reqCtx, &grpc_testing.StreamingOutputCallRequest{})
+			if streamErr != nil {
+				firstCallErr <- streamErr
+				return
+			}
+			if _, recvErr := stream.Recv(); recvErr != nil {
+				firstCallErr <- recvErr
+			}
+		}
+	}()
+
+	// Wait for first request to be acquired
+	<-acquired
+
+	// Second request should timeout in backlog
+	startTime := time.Now()
+	if s.IsUnary {
+		_, unaryErr := client.UnaryCall(reqCtx, &grpc_testing.SimpleRequest{})
+		s.Require().Error(unaryErr)
+		s.Require().Equal(codes.ResourceExhausted, status.Code(unaryErr))
+	} else {
+		stream, streamErr := client.StreamingOutputCall(reqCtx, &grpc_testing.StreamingOutputCallRequest{})
+		s.Require().NoError(streamErr)
+		_, recvErr := stream.Recv()
+		s.Require().Error(recvErr)
+		s.Require().Equal(codes.ResourceExhausted, status.Code(recvErr))
+	}
+	duration := time.Since(startTime)
+
+	// Should have timed out after the backlog timeout
+	s.Require().GreaterOrEqual(duration, backlogTimeout)
+	s.Require().LessOrEqual(duration, backlogTimeout+100*time.Millisecond) // Some tolerance
+
+	// Release first request
+	close(release)
+
+	// Check that the first call completed successfully
+	select {
+	case <-firstCallDone:
+	case <-time.After(5 * time.Second):
+		s.Fail("First request did not complete in time")
+	}
+	testutil.RequireNoErrorInChannel(s.T(), firstCallErr, 5*time.Second)
+}
+
+func (s *InFlightLimitInterceptorTestSuite) TestInFlightLimitInterceptor_CustomCallbacks() {
+	limit := 1
+
+	var rejectedCalled bool
+	customUnaryOnReject := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler, params InFlightLimitParams) (interface{}, error) {
+		rejectedCalled = true
+		return nil, status.Error(codes.Unavailable, "custom rejection message")
+	}
+	customStreamOnReject := func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler, params InFlightLimitParams) error {
+		rejectedCalled = true
+		return status.Error(codes.Unavailable, "custom rejection message")
+	}
+
+	logger := logtest.NewRecorder()
+	svc, client, closeSvc, err := s.setupTestService(logger, limit, []InFlightLimitOption{
+		WithInFlightLimitUnaryOnReject(customUnaryOnReject),
+		WithInFlightLimitStreamOnReject(customStreamOnReject),
+	})
+	s.Require().NoError(err)
+	defer func() { s.Require().NoError(closeSvc()) }()
+
+	// Set up slow handlers to create in-flight requests
+	acquired := make(chan struct{})
+	release := make(chan struct{})
+
+	if s.IsUnary {
+		svc.SwitchUnaryCallHandler(func(ctx context.Context, req *grpc_testing.SimpleRequest) (*grpc_testing.SimpleResponse, error) {
+			acquired <- struct{}{}
+			<-release
+			return &grpc_testing.SimpleResponse{Payload: &grpc_testing.Payload{Body: []byte("test")}}, nil
+		})
+	} else {
+		svc.SwitchStreamingOutputCallHandler(func(req *grpc_testing.StreamingOutputCallRequest, stream grpc_testing.TestService_StreamingOutputCallServer) error {
+			acquired <- struct{}{}
+			<-release
+			return stream.Send(&grpc_testing.StreamingOutputCallResponse{
+				Payload: &grpc_testing.Payload{Body: []byte("test-stream")},
+			})
+		})
+	}
+
+	reqCtx := context.Background()
+
+	// Start first request
+	firstCallErr := make(chan error, 1)
+	firstCallDone := make(chan struct{})
+	go func() {
+		defer close(firstCallDone)
+		if s.IsUnary {
+			_, unaryErr := client.UnaryCall(reqCtx, &grpc_testing.SimpleRequest{})
+			if unaryErr != nil {
+				firstCallErr <- unaryErr
+			}
+		} else {
+			stream, streamErr := client.StreamingOutputCall(reqCtx, &grpc_testing.StreamingOutputCallRequest{})
+			if streamErr != nil {
+				firstCallErr <- streamErr
+				return
+			}
+			if _, recvErr := stream.Recv(); recvErr != nil {
+				firstCallErr <- recvErr
+			}
+		}
+	}()
+
+	// Wait for first request to be acquired
+	<-acquired
+
+	// Second request should be rejected with custom callback
+	if s.IsUnary {
+		_, unaryErr := client.UnaryCall(reqCtx, &grpc_testing.SimpleRequest{})
+		s.Require().Error(unaryErr)
+		s.Require().Equal(codes.Unavailable, status.Code(unaryErr))
+		s.Require().Contains(unaryErr.Error(), "custom rejection message")
+	} else {
+		stream, streamErr := client.StreamingOutputCall(reqCtx, &grpc_testing.StreamingOutputCallRequest{})
+		s.Require().NoError(streamErr)
+		_, recvErr := stream.Recv()
+		s.Require().Error(recvErr)
+		s.Require().Equal(codes.Unavailable, status.Code(recvErr))
+		s.Require().Contains(recvErr.Error(), "custom rejection message")
+	}
+
+	s.Require().True(rejectedCalled)
+
+	// Release first request
+	close(release)
+
+	// Check that the first call completed successfully
+	select {
+	case <-firstCallDone:
+	case <-time.After(5 * time.Second):
+		s.Fail("First request did not complete in time")
+	}
+	testutil.RequireNoErrorInChannel(s.T(), firstCallErr, 5*time.Second)
+}
+
+func (s *InFlightLimitInterceptorTestSuite) TestInFlightLimitInterceptor_RetryAfterHeader() {
+	limit := 1
+	retryAfter := 3 * time.Second
+
+	customUnaryGetRetryAfter := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo) time.Duration {
+		return retryAfter
+	}
+	customStreamGetRetryAfter := func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo) time.Duration {
+		return retryAfter
+	}
+
+	logger := logtest.NewRecorder()
+	svc, client, closeSvc, err := s.setupTestService(logger, limit, []InFlightLimitOption{
+		WithInFlightLimitUnaryGetRetryAfter(customUnaryGetRetryAfter),
+		WithInFlightLimitStreamGetRetryAfter(customStreamGetRetryAfter),
+	})
+	s.Require().NoError(err)
+	defer func() { s.Require().NoError(closeSvc()) }()
+
+	// Set up slow handlers to create in-flight requests
+	acquired := make(chan struct{})
+	release := make(chan struct{})
+
+	if s.IsUnary {
+		svc.SwitchUnaryCallHandler(func(ctx context.Context, req *grpc_testing.SimpleRequest) (*grpc_testing.SimpleResponse, error) {
+			acquired <- struct{}{}
+			<-release
+			return &grpc_testing.SimpleResponse{Payload: &grpc_testing.Payload{Body: []byte("test")}}, nil
+		})
+	} else {
+		svc.SwitchStreamingOutputCallHandler(func(req *grpc_testing.StreamingOutputCallRequest, stream grpc_testing.TestService_StreamingOutputCallServer) error {
+			acquired <- struct{}{}
+			<-release
+			return stream.Send(&grpc_testing.StreamingOutputCallResponse{
+				Payload: &grpc_testing.Payload{Body: []byte("test-stream")},
+			})
+		})
+	}
+
+	reqCtx := context.Background()
+
+	// Start first request
+	firstCallErr := make(chan error, 1)
+	firstCallDone := make(chan struct{})
+	go func() {
+		defer close(firstCallDone)
+		if s.IsUnary {
+			_, unaryErr := client.UnaryCall(reqCtx, &grpc_testing.SimpleRequest{})
+			if unaryErr != nil {
+				firstCallErr <- unaryErr
+			}
+		} else {
+			stream, streamErr := client.StreamingOutputCall(reqCtx, &grpc_testing.StreamingOutputCallRequest{})
+			if streamErr != nil {
+				firstCallErr <- streamErr
+				return
+			}
+			if _, recvErr := stream.Recv(); recvErr != nil {
+				firstCallErr <- recvErr
+			}
+		}
+	}()
+
+	// Wait for first request to be acquired
+	<-acquired
+
+	// Second request should be rejected with retry-after header
+	var headers metadata.MD
+	if s.IsUnary {
+		_, unaryErr := client.UnaryCall(reqCtx, &grpc_testing.SimpleRequest{}, grpc.Header(&headers))
+		s.Require().Error(unaryErr)
+		s.Require().Equal(codes.ResourceExhausted, status.Code(unaryErr))
+	} else {
+		stream, streamErr := client.StreamingOutputCall(reqCtx, &grpc_testing.StreamingOutputCallRequest{}, grpc.Header(&headers))
+		s.Require().NoError(streamErr)
+		_, recvErr := stream.Recv()
+		s.Require().Error(recvErr)
+		s.Require().Equal(codes.ResourceExhausted, status.Code(recvErr))
+	}
+
+	// Check retry-after header
+	retryAfterHeaders := headers.Get("retry-after")
+	s.Require().Len(retryAfterHeaders, 1)
+	retryAfterSecs, parseErr := strconv.Atoi(retryAfterHeaders[0])
+	s.Require().NoError(parseErr)
+	s.Require().Equal(int(retryAfter.Seconds()), retryAfterSecs)
+
+	// Release first request
+	close(release)
+
+	// Check that the first call completed successfully
+	select {
+	case <-firstCallDone:
+	case <-time.After(5 * time.Second):
+		s.Fail("First request did not complete in time")
+	}
+	testutil.RequireNoErrorInChannel(s.T(), firstCallErr, 5*time.Second)
+}
+
+func (s *InFlightLimitInterceptorTestSuite) TestInFlightLimitInterceptor_InvalidOptions() {
+	tests := []struct {
+		name        string
+		limit       int
+		options     []InFlightLimitOption
+		expectError string
+	}{
+		{
+			name:        "zero limit",
+			limit:       0,
+			expectError: "limit should be positive",
+		},
+		{
+			name:        "negative limit",
+			limit:       -1,
+			expectError: "limit should be positive",
+		},
+		{
+			name:        "negative backlog limit",
+			limit:       1,
+			options:     []InFlightLimitOption{WithInFlightLimitBacklogLimit(-1)},
+			expectError: "backlog limit should not be negative",
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			var err error
+			if s.IsUnary {
+				_, err = InFlightLimitUnaryInterceptor(tt.limit, tt.options...)
+			} else {
+				_, err = InFlightLimitStreamInterceptor(tt.limit, tt.options...)
+			}
+			s.Require().Error(err)
+			s.Require().Contains(err.Error(), tt.expectError)
+		})
+	}
+}
+
+func (s *InFlightLimitInterceptorTestSuite) TestInFlightLimitInterceptor_DefaultHandlers() {
+	// Test default reject handler with mock context and parameters
+	ctx := context.Background()
+	logger := logtest.NewRecorder()
+	ctx = NewContextWithLogger(ctx, logger)
+
+	params := InFlightLimitParams{
+		Key:               "test-key",
+		RequestBacklogged: false,
+	}
+
+	// Test DefaultInFlightLimitUnaryOnReject
+	if s.IsUnary {
+		result, err := DefaultInFlightLimitUnaryOnReject(ctx, &grpc_testing.SimpleRequest{},
+			&grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, nil, params)
+		s.Require().Error(err)
+		s.Nil(result)
+		s.Equal(codes.ResourceExhausted, status.Code(err))
+		s.Contains(err.Error(), "Too many in-flight requests")
+	} else {
+		// Test DefaultInFlightLimitStreamOnReject
+		mockStream := &mockServerStream{ctx: ctx}
+		err := DefaultInFlightLimitStreamOnReject(nil, mockStream,
+			&grpc.StreamServerInfo{FullMethod: "/test.Service/Method"}, nil, params)
+		s.Require().Error(err)
+		s.Equal(codes.ResourceExhausted, status.Code(err))
+		s.Contains(err.Error(), "Too many in-flight requests")
+	}
+
+	// Verify warning log was created
+	entries := logger.Entries()
+	s.Require().Greater(len(entries), 0)
+	found := false
+	for _, entry := range entries {
+		if entry.Level == log.LevelWarn && entry.Text == "in-flight limit exceeded" {
+			found = true
+			break
+		}
+	}
+	s.True(found, "Should log in-flight limit exceeded warning")
+}
+
+func (s *InFlightLimitInterceptorTestSuite) TestInFlightLimitInterceptor_DefaultErrorHandlers() {
+	ctx := context.Background()
+	logger := logtest.NewRecorder()
+	ctx = NewContextWithLogger(ctx, logger)
+
+	params := InFlightLimitParams{
+		Key:               "test-key",
+		RequestBacklogged: false,
+	}
+
+	testErr := status.Error(codes.Internal, "test error")
+
+	// Test DefaultInFlightLimitUnaryOnError
+	if s.IsUnary {
+		result, err := DefaultInFlightLimitUnaryOnError(ctx, &grpc_testing.SimpleRequest{},
+			&grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, nil, params, testErr)
+		s.Require().Error(err)
+		s.Nil(result)
+		s.Equal(codes.Internal, status.Code(err))
+		s.Contains(err.Error(), "Internal server error")
+	} else {
+		// Test DefaultInFlightLimitStreamOnError
+		mockStream := &mockServerStream{ctx: ctx}
+		err := DefaultInFlightLimitStreamOnError(nil, mockStream,
+			&grpc.StreamServerInfo{FullMethod: "/test.Service/Method"}, nil, params, testErr)
+		s.Require().Error(err)
+		s.Equal(codes.Internal, status.Code(err))
+		s.Contains(err.Error(), "Internal server error")
+	}
+
+	// Verify error log was created
+	entries := logger.Entries()
+	s.Require().Greater(len(entries), 0)
+	found := false
+	for _, entry := range entries {
+		if entry.Level == log.LevelError && entry.Text == "in-flight limiting error" {
+			found = true
+			break
+		}
+	}
+	s.True(found, "Should log in-flight limiting error")
+}
+
+func (s *InFlightLimitInterceptorTestSuite) TestInFlightLimitInterceptor_DryRunHandlers() {
+	ctx := context.Background()
+	logger := logtest.NewRecorder()
+	ctx = NewContextWithLogger(ctx, logger)
+
+	params := InFlightLimitParams{
+		Key:               "test-key",
+		RequestBacklogged: false,
+	}
+
+	handlerCalled := false
+	mockHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		handlerCalled = true
+		return "success", nil
+	}
+	mockStreamHandler := func(srv interface{}, ss grpc.ServerStream) error {
+		handlerCalled = true
+		return nil
+	}
+
+	// Test DefaultInFlightLimitUnaryOnRejectInDryRun
+	if s.IsUnary {
+		result, err := DefaultInFlightLimitUnaryOnRejectInDryRun(ctx, &grpc_testing.SimpleRequest{},
+			&grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, mockHandler, params)
+		s.Require().NoError(err)
+		s.Equal("success", result)
+		s.True(handlerCalled)
+	} else {
+		// Test DefaultInFlightLimitStreamOnRejectInDryRun
+		mockStream := &mockServerStream{ctx: ctx}
+		err := DefaultInFlightLimitStreamOnRejectInDryRun(nil, mockStream,
+			&grpc.StreamServerInfo{FullMethod: "/test.Service/Method"}, mockStreamHandler, params)
+		s.Require().NoError(err)
+		s.True(handlerCalled)
+	}
+
+	// Verify dry run warning log was created
+	entries := logger.Entries()
+	s.Require().Greater(len(entries), 0)
+	found := false
+	for _, entry := range entries {
+		if entry.Level == log.LevelWarn && entry.Text == "in-flight limit exceeded, continuing in dry run mode" {
+			found = true
+			break
+		}
+	}
+	s.True(found, "Should log dry run warning")
+}
+
+func (s *InFlightLimitInterceptorTestSuite) TestInFlightLimitInterceptor_GetKeyError() {
+	limit := 1
+
+	// Create get key functions that return an error
+	errorUnaryGetKey := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo) (string, bool, error) {
+		return "", false, status.Error(codes.InvalidArgument, "key extraction failed")
+	}
+	errorStreamGetKey := func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo) (string, bool, error) {
+		return "", false, status.Error(codes.InvalidArgument, "key extraction failed")
+	}
+
+	var options []InFlightLimitOption
+	if s.IsUnary {
+		options = []InFlightLimitOption{WithInFlightLimitUnaryGetKey(errorUnaryGetKey)}
+	} else {
+		options = []InFlightLimitOption{WithInFlightLimitStreamGetKey(errorStreamGetKey)}
+	}
+
+	logger := logtest.NewRecorder()
+	_, client, closeSvc, err := s.setupTestService(logger, limit, options)
+	s.Require().NoError(err)
+	defer func() { s.Require().NoError(closeSvc()) }()
+
+	reqCtx := context.Background()
+
+	// Request should fail due to key extraction error
+	if s.IsUnary {
+		_, unaryErr := client.UnaryCall(reqCtx, &grpc_testing.SimpleRequest{})
+		s.Require().Error(unaryErr)
+		s.Equal(codes.Internal, status.Code(unaryErr))
+	} else {
+		stream, streamErr := client.StreamingOutputCall(reqCtx, &grpc_testing.StreamingOutputCallRequest{})
+		s.Require().NoError(streamErr)
+		_, recvErr := stream.Recv()
+		s.Require().Error(recvErr)
+		s.Equal(codes.Internal, status.Code(recvErr))
+	}
+}
+
+func (s *InFlightLimitInterceptorTestSuite) TestInFlightLimitInterceptor_MaxKeys() {
+	limit := 1
+	maxKeys := 1
+
+	getUnaryKeyByIndex := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo) (string, bool, error) {
+		if md, ok := metadata.FromIncomingContext(ctx); ok {
+			if indexes := md.Get("index"); len(indexes) > 0 {
+				return indexes[0], false, nil
+			}
+		}
+		return "default", false, nil
+	}
+
+	getStreamKeyByIndex := func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo) (string, bool, error) {
+		if md, ok := metadata.FromIncomingContext(ss.Context()); ok {
+			if indexes := md.Get("index"); len(indexes) > 0 {
+				return indexes[0], false, nil
+			}
+		}
+		return "default", false, nil
+	}
+
+	logger := logtest.NewRecorder()
+	_, client, closeSvc, err := s.setupTestService(logger, limit, []InFlightLimitOption{
+		WithInFlightLimitUnaryGetKey(getUnaryKeyByIndex),
+		WithInFlightLimitStreamGetKey(getStreamKeyByIndex),
+		WithInFlightLimitMaxKeys(maxKeys),
+	})
+	s.Require().NoError(err)
+	defer func() { s.Require().NoError(closeSvc()) }()
+
+	// With maxKeys=1, only one key can be tracked at a time
+	// When a new key is used, the old one should be evicted from the LRU cache
+
+	ctx1 := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("index", "1"))
+	ctx2 := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("index", "2"))
+
+	// Make request with key "1" - should succeed
+	if s.IsUnary {
+		_, err = client.UnaryCall(ctx1, &grpc_testing.SimpleRequest{})
+		s.Require().NoError(err)
+	} else {
+		stream, streamErr := client.StreamingOutputCall(ctx1, &grpc_testing.StreamingOutputCallRequest{})
+		s.Require().NoError(streamErr)
+		_, recvErr := stream.Recv()
+		s.Require().NoError(recvErr)
+	}
+
+	// Make request with key "2" - should succeed (evicts key "1" from cache)
+	if s.IsUnary {
+		_, err = client.UnaryCall(ctx2, &grpc_testing.SimpleRequest{})
+		s.Require().NoError(err)
+	} else {
+		stream, streamErr := client.StreamingOutputCall(ctx2, &grpc_testing.StreamingOutputCallRequest{})
+		s.Require().NoError(streamErr)
+		_, recvErr := stream.Recv()
+		s.Require().NoError(recvErr)
+	}
+
+	// Make another request with key "1" - should succeed because key "1" was evicted and recreated
+	if s.IsUnary {
+		_, err = client.UnaryCall(ctx1, &grpc_testing.SimpleRequest{})
+		s.Require().NoError(err)
+	} else {
+		stream, streamErr := client.StreamingOutputCall(ctx1, &grpc_testing.StreamingOutputCallRequest{})
+		s.Require().NoError(streamErr)
+		_, recvErr := stream.Recv()
+		s.Require().NoError(recvErr)
+	}
+}
+
+// Helper methods
+
+func (s *InFlightLimitInterceptorTestSuite) setupSlowHandlers(svc *testService, delay time.Duration) {
+	if s.IsUnary {
+		svc.SwitchUnaryCallHandler(func(ctx context.Context, req *grpc_testing.SimpleRequest) (*grpc_testing.SimpleResponse, error) {
+			time.Sleep(delay)
+			return &grpc_testing.SimpleResponse{Payload: &grpc_testing.Payload{Body: []byte("test")}}, nil
+		})
+	} else {
+		svc.SwitchStreamingOutputCallHandler(func(req *grpc_testing.StreamingOutputCallRequest, stream grpc_testing.TestService_StreamingOutputCallServer) error {
+			time.Sleep(delay)
+			return stream.Send(&grpc_testing.StreamingOutputCallResponse{
+				Payload: &grpc_testing.Payload{Body: []byte("test-stream")},
+			})
+		})
+	}
+}
+
+func (s *InFlightLimitInterceptorTestSuite) setupTestService(
+	logger *logtest.Recorder, limit int, options []InFlightLimitOption,
+) (*testService, grpc_testing.TestServiceClient, func() error, error) {
+	var serverOptions []grpc.ServerOption
+	if s.IsUnary {
+		unaryInterceptor, err := InFlightLimitUnaryInterceptor(limit, options...)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		loggingInterceptor := func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
+			return handler(NewContextWithLogger(ctx, logger), req)
+		}
+		serverOptions = append(serverOptions, grpc.ChainUnaryInterceptor(loggingInterceptor, unaryInterceptor))
+	} else {
+		streamInterceptor, err := InFlightLimitStreamInterceptor(limit, options...)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		loggingInterceptor := func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+			wrappedStream := &WrappedServerStream{ServerStream: ss, Ctx: NewContextWithLogger(ss.Context(), logger)}
+			return handler(srv, wrappedStream)
+		}
+		serverOptions = append(serverOptions, grpc.ChainStreamInterceptor(loggingInterceptor, streamInterceptor))
+	}
+
+	return startTestService(serverOptions, nil)
+}
+
+func (s *InFlightLimitInterceptorTestSuite) TestWithInFlightLimitOnRejectInDryRun() {
+	limit := 1
+
+	var customHandlerCalls atomic.Int32
+
+	customUnaryRejectInDryRun := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler, params InFlightLimitParams) (interface{}, error) {
+		customHandlerCalls.Inc()
+		return handler(ctx, req)
+	}
+
+	customStreamRejectInDryRun := func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler, params InFlightLimitParams) error {
+		customHandlerCalls.Inc()
+		return handler(srv, ss)
+	}
+
+	logger := logtest.NewRecorder()
+	svc, client, closeSvc, err := s.setupTestService(logger, limit, []InFlightLimitOption{
+		WithInFlightLimitDryRun(true),
+		WithInFlightLimitUnaryOnRejectInDryRun(customUnaryRejectInDryRun),
+		WithInFlightLimitStreamOnRejectInDryRun(customStreamRejectInDryRun),
+	})
+	s.Require().NoError(err)
+	defer func() { s.Require().NoError(closeSvc()) }()
+
+	// Set up slow handlers to create in-flight requests
+	s.setupSlowHandlers(svc, 100*time.Millisecond)
+
+	reqCtx := context.Background()
+
+	// Launch multiple concurrent requests to trigger dry run rejection
+	var wg sync.WaitGroup
+	concurrentReqs := 3
+	var successCount atomic.Int32
+
+	for i := 0; i < concurrentReqs; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var headers metadata.MD
+			if s.IsUnary {
+				_, unaryErr := client.UnaryCall(reqCtx, &grpc_testing.SimpleRequest{}, grpc.Header(&headers))
+				if unaryErr == nil {
+					successCount.Inc()
+				}
+			} else {
+				stream, streamErr := client.StreamingOutputCall(reqCtx, &grpc_testing.StreamingOutputCallRequest{}, grpc.Header(&headers))
+				if streamErr == nil {
+					if _, recvErr := stream.Recv(); recvErr == nil {
+						successCount.Inc()
+					}
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	// All requests should succeed in dry run mode
+	s.Require().Equal(concurrentReqs, int(successCount.Load()), "All requests should succeed in dry run mode")
+	s.Require().Equal(concurrentReqs-1, int(customHandlerCalls.Load()), "Custom dry run reject handler should have been called")
+}
+
+func (s *InFlightLimitInterceptorTestSuite) TestWithInFlightLimitOnError() {
+	limit := 1
+
+	customUnaryOnError := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler, params InFlightLimitParams, err error) (interface{}, error) {
+		// Custom error handling: log the error with custom context and return a different error
+		logger := GetLoggerFromContext(ctx)
+		if logger != nil {
+			logger.Error("custom in-flight limit error handler",
+				log.String("method", info.FullMethod),
+				log.String("key", params.Key),
+				log.Error(err),
+			)
+		}
+		return nil, status.Error(codes.FailedPrecondition, "custom error response")
+	}
+
+	customStreamOnError := func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler, params InFlightLimitParams, err error) error {
+		// Custom error handling: log the error with custom context and return a different error
+		logger := GetLoggerFromContext(ss.Context())
+		if logger != nil {
+			logger.Error("custom in-flight limit error handler",
+				log.String("method", info.FullMethod),
+				log.String("key", params.Key),
+				log.Error(err),
+			)
+		}
+		return status.Error(codes.FailedPrecondition, "custom error response")
+	}
+
+	// Create get key functions that will cause an error
+	errorUnaryGetKey := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo) (string, bool, error) {
+		return "", false, status.Error(codes.InvalidArgument, "key extraction failed")
+	}
+
+	errorStreamGetKey := func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo) (string, bool, error) {
+		return "", false, status.Error(codes.InvalidArgument, "key extraction failed")
+	}
+
+	logger := logtest.NewRecorder()
+	_, client, closeSvc, err := s.setupTestService(logger, limit, []InFlightLimitOption{
+		WithInFlightLimitUnaryGetKey(errorUnaryGetKey),
+		WithInFlightLimitStreamGetKey(errorStreamGetKey),
+		WithInFlightLimitUnaryOnError(customUnaryOnError),
+		WithInFlightLimitStreamOnError(customStreamOnError),
+	})
+	s.Require().NoError(err)
+	defer func() { s.Require().NoError(closeSvc()) }()
+
+	reqCtx := context.Background()
+
+	// Request should fail with custom error response
+	if s.IsUnary {
+		_, unaryErr := client.UnaryCall(reqCtx, &grpc_testing.SimpleRequest{})
+		s.Require().Error(unaryErr)
+		s.Require().Equal(codes.FailedPrecondition, status.Code(unaryErr))
+		s.Require().Contains(unaryErr.Error(), "custom error response")
+	} else {
+		stream, streamErr := client.StreamingOutputCall(reqCtx, &grpc_testing.StreamingOutputCallRequest{})
+		s.Require().NoError(streamErr)
+		_, recvErr := stream.Recv()
+		s.Require().Error(recvErr)
+		s.Require().Equal(codes.FailedPrecondition, status.Code(recvErr))
+		s.Require().Contains(recvErr.Error(), "custom error response")
+	}
+
+	// Check that custom error handler was called by verifying log entry
+	entries := logger.Entries()
+	s.Require().Greater(len(entries), 0)
+	found := false
+	for _, entry := range entries {
+		if entry.Level == log.LevelError && entry.Text == "custom in-flight limit error handler" {
+			found = true
+			break
+		}
+	}
+	s.Require().True(found, "Custom error handler should have been called")
+}
+
+func (s *InFlightLimitInterceptorTestSuite) TestWithInFlightLimitDryRunCallbackPriority() {
+	limit := 1
+
+	var regularRejectCalled atomic.Bool
+	var dryRunRejectCalled atomic.Bool
+
+	regularUnaryOnReject := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler, params InFlightLimitParams) (interface{}, error) {
+		regularRejectCalled.Store(true)
+		return nil, status.Error(codes.ResourceExhausted, "regular rejection")
+	}
+
+	dryRunUnaryOnReject := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler, params InFlightLimitParams) (interface{}, error) {
+		dryRunRejectCalled.Store(true)
+		return handler(ctx, req)
+	}
+
+	regularStreamOnReject := func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler, params InFlightLimitParams) error {
+		regularRejectCalled.Store(true)
+		return status.Error(codes.ResourceExhausted, "regular rejection")
+	}
+
+	dryRunStreamOnReject := func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler, params InFlightLimitParams) error {
+		dryRunRejectCalled.Store(true)
+		return handler(srv, ss)
+	}
+
+	logger := logtest.NewRecorder()
+	options := []InFlightLimitOption{
+		WithInFlightLimitDryRun(true),
+		WithInFlightLimitUnaryOnReject(regularUnaryOnReject),
+		WithInFlightLimitStreamOnReject(regularStreamOnReject),
+		WithInFlightLimitUnaryOnRejectInDryRun(dryRunUnaryOnReject),
+		WithInFlightLimitStreamOnRejectInDryRun(dryRunStreamOnReject),
+	}
+
+	svc, client, closeSvc, err := s.setupTestService(logger, limit, options)
+	s.Require().NoError(err)
+	defer func() { s.Require().NoError(closeSvc()) }()
+
+	// Set up slow handlers to create in-flight requests
+	s.setupSlowHandlers(svc, 100*time.Millisecond)
+
+	reqCtx := context.Background()
+
+	// Launch multiple concurrent requests to trigger dry run rejection
+	var wg sync.WaitGroup
+	concurrentReqs := 3
+	var successCount atomic.Int32
+
+	for i := 0; i < concurrentReqs; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if s.IsUnary {
+				_, unaryErr := client.UnaryCall(reqCtx, &grpc_testing.SimpleRequest{})
+				if unaryErr == nil {
+					successCount.Inc()
+				}
+			} else {
+				stream, streamErr := client.StreamingOutputCall(reqCtx, &grpc_testing.StreamingOutputCallRequest{})
+				if streamErr == nil {
+					_, recvErr := stream.Recv()
+					if recvErr == nil {
+						successCount.Inc()
+					}
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	// All requests should succeed in dry run mode
+	s.Require().Equal(concurrentReqs, int(successCount.Load()), "All requests should succeed in dry run mode")
+
+	// Verify that dry run callback was called, not regular callback
+	s.Require().True(dryRunRejectCalled.Load(), "Dry run callback should have been called")
+	s.Require().False(regularRejectCalled.Load(), "Regular callback should NOT have been called in dry run mode")
+}
+
+func (s *InFlightLimitInterceptorTestSuite) TestWithInFlightLimitErrorCallbackWithParams() {
+	limit := 1
+
+	var receivedParams InFlightLimitParams
+	var receivedError error
+
+	customUnaryOnError := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler, params InFlightLimitParams, err error) (interface{}, error) {
+		receivedParams = params
+		receivedError = err
+		return nil, status.Error(codes.Aborted, "test completed")
+	}
+
+	customStreamOnError := func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler, params InFlightLimitParams, err error) error {
+		receivedParams = params
+		receivedError = err
+		return status.Error(codes.Aborted, "test completed")
+	}
+
+	// Create a get key function that will cause a specific error
+	testKey := "test-key-123"
+	errorGetKey := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo) (string, bool, error) {
+		return testKey, false, status.Error(codes.PermissionDenied, "permission denied for key extraction")
+	}
+	errorStreamGetKey := func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo) (string, bool, error) {
+		return testKey, false, status.Error(codes.PermissionDenied, "permission denied for key extraction")
+	}
+
+	logger := logtest.NewRecorder()
+	options := []InFlightLimitOption{
+		WithInFlightLimitUnaryOnError(customUnaryOnError),
+		WithInFlightLimitStreamOnError(customStreamOnError),
+	}
+
+	if s.IsUnary {
+		options = append(options, WithInFlightLimitUnaryGetKey(errorGetKey))
+	} else {
+		options = append(options, WithInFlightLimitStreamGetKey(errorStreamGetKey))
+	}
+
+	_, client, closeSvc, err := s.setupTestService(logger, limit, options)
+	s.Require().NoError(err)
+	defer func() { s.Require().NoError(closeSvc()) }()
+
+	reqCtx := context.Background()
+
+	// Request should trigger error callback
+	if s.IsUnary {
+		_, unaryErr := client.UnaryCall(reqCtx, &grpc_testing.SimpleRequest{})
+		s.Require().Error(unaryErr)
+		s.Require().Equal(codes.Aborted, status.Code(unaryErr))
+	} else {
+		stream, streamErr := client.StreamingOutputCall(reqCtx, &grpc_testing.StreamingOutputCallRequest{})
+		s.Require().NoError(streamErr)
+		_, recvErr := stream.Recv()
+		s.Require().Error(recvErr)
+		s.Require().Equal(codes.Aborted, status.Code(recvErr))
+	}
+
+	// Verify that error callback received correct parameters
+	s.Require().Equal(testKey, receivedParams.Key, "Error callback should receive correct key")
+	s.Require().NotNil(receivedError, "Error callback should receive the original error")
+	s.Require().Equal(codes.PermissionDenied, status.Code(receivedError), "Error callback should receive original error code")
+	s.Require().Contains(receivedError.Error(), "permission denied for key extraction", "Error callback should receive original error message")
+}

--- a/internal/inflightlimit/doc.go
+++ b/internal/inflightlimit/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright © 2025 Acronis International GmbH.
+
+Released under MIT license.
+*/
+
+// Package inflightlimit provides in-flight request limiting functionality to control
+// the number of concurrent requests being processed at any given time.
+//
+// The package implements a generic RequestProcessor that can be used with both HTTP
+// and gRPC requests to enforce in-flight limits with optional backlog queuing.
+// When the in-flight limit is reached, requests can be queued in a backlog with
+// configurable timeout, or rejected immediately if the backlog is full.
+//
+// Key features:
+//   - Configurable in-flight limits per key or globally
+//   - Optional backlog queuing with timeout
+//   - Dry-run mode for testing
+//   - LRU-based key management for memory efficiency
+package inflightlimit

--- a/internal/inflightlimit/request_processor.go
+++ b/internal/inflightlimit/request_processor.go
@@ -1,0 +1,189 @@
+/*
+Copyright © 2025 Acronis International GmbH.
+
+Released under MIT license.
+*/
+
+package inflightlimit
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/acronis/go-appkit/lrucache"
+)
+
+// DefaultInFlightLimitBacklogTimeout determines the default timeout for backlog processing.
+const DefaultInFlightLimitBacklogTimeout = time.Second * 5
+
+// Params contains common data that relates to the in-flight limiting procedure.
+type Params struct {
+	Key               string
+	RequestBacklogged bool
+}
+
+// RequestHandler abstracts the common operations for both HTTP and gRPC requests.
+type RequestHandler interface {
+	// GetContext returns the request context.
+	GetContext() context.Context
+
+	// GetKey extracts the in-flight limiting key from the request.
+	// Returns key, bypass (whether to bypass in-flight limiting), and error.
+	GetKey() (string, bool, error)
+
+	// Execute processes the actual request.
+	Execute() error
+
+	// OnReject handles request rejection when in-flight limit is exceeded.
+	OnReject(params Params) error
+
+	// OnError handles errors that occur during in-flight limiting.
+	OnError(params Params, err error) error
+}
+
+// RequestProcessor handles the common in-flight limiting logic for any request type.
+type RequestProcessor struct {
+	limit          int
+	getSlots       slotsProvider
+	backlogTimeout time.Duration
+	dryRun         bool
+}
+
+// BacklogParams defines parameters for the backlog processing.
+type BacklogParams struct {
+	MaxKeys int
+	Limit   int
+	Timeout time.Duration
+}
+
+// slotsProvider provides in-flight and backlog slots for limiting.
+type slotsProvider func(key string) (inFlightSlots chan struct{}, backlogSlots chan struct{})
+
+// NewRequestProcessor creates a new generic in-flight request processor.
+func NewRequestProcessor(limit int, backlogParams BacklogParams, dryRun bool) (*RequestProcessor, error) {
+	if limit <= 0 {
+		return nil, fmt.Errorf("limit should be positive, got %d", limit)
+	}
+	if backlogParams.Limit < 0 {
+		return nil, fmt.Errorf("backlog limit should not be negative, got %d", backlogParams.Limit)
+	}
+	if backlogParams.MaxKeys < 0 {
+		return nil, fmt.Errorf("max keys for backlog should not be negative, got %d", backlogParams.MaxKeys)
+	}
+
+	getSlots, err := newSlotsProvider(limit, backlogParams.Limit, backlogParams.MaxKeys)
+	if err != nil {
+		return nil, fmt.Errorf("create slots provider: %w", err)
+	}
+
+	if backlogParams.Timeout == 0 {
+		backlogParams.Timeout = DefaultInFlightLimitBacklogTimeout
+	}
+
+	return &RequestProcessor{
+		limit:          limit,
+		getSlots:       getSlots,
+		backlogTimeout: backlogParams.Timeout,
+		dryRun:         dryRun,
+	}, nil
+}
+
+// ProcessRequest contains the shared in-flight limiting logic.
+func (p *RequestProcessor) ProcessRequest(rh RequestHandler) error {
+	key, bypass, err := rh.GetKey()
+	if err != nil {
+		return rh.OnError(Params{Key: key}, fmt.Errorf("get key for in-flight limit: %w", err))
+	}
+	if bypass {
+		return rh.Execute()
+	}
+
+	slots, backlogSlots := p.getSlots(key)
+
+	backlogged := false
+	defer func() {
+		if backlogged {
+			select {
+			case <-backlogSlots:
+			default:
+			}
+		}
+	}()
+
+	select {
+	case backlogSlots <- struct{}{}:
+		backlogged = true
+	default:
+		return rh.OnReject(Params{Key: key, RequestBacklogged: false})
+	}
+
+	return p.processBackloggedRequest(rh, key, slots)
+}
+
+// processBackloggedRequest handles a request that has been placed in the backlog queue.
+func (p *RequestProcessor) processBackloggedRequest(rh RequestHandler, key string, slots chan struct{}) error {
+	acquired := false
+	defer func() {
+		if acquired {
+			select {
+			case <-slots:
+			default:
+			}
+		}
+	}()
+
+	if p.dryRun {
+		select {
+		case slots <- struct{}{}:
+			acquired = true
+			return rh.Execute()
+		default:
+			return rh.OnReject(Params{Key: key, RequestBacklogged: true})
+		}
+	}
+
+	ctx := rh.GetContext()
+	backlogTimeoutTimer := time.NewTimer(p.backlogTimeout)
+	defer backlogTimeoutTimer.Stop()
+
+	select {
+	case slots <- struct{}{}:
+		acquired = true
+		return rh.Execute()
+	case <-backlogTimeoutTimer.C:
+		return rh.OnReject(Params{Key: key, RequestBacklogged: true})
+	case <-ctx.Done():
+		return rh.OnError(Params{Key: key, RequestBacklogged: true}, ctx.Err())
+	}
+}
+
+// newSlotsProvider creates a new slots provider for in-flight and backlog limiting.
+func newSlotsProvider(limit, backlogLimit, maxKeys int) (slotsProvider, error) {
+	if maxKeys == 0 {
+		slots := make(chan struct{}, limit)
+		backlogSlots := make(chan struct{}, limit+backlogLimit)
+		return func(key string) (chan struct{}, chan struct{}) {
+			return slots, backlogSlots
+		}, nil
+	}
+
+	type KeysZoneItem struct {
+		slots        chan struct{}
+		backlogSlots chan struct{}
+	}
+
+	keysZone, err := lrucache.New[string, *KeysZoneItem](maxKeys, nil)
+	if err != nil {
+		return nil, fmt.Errorf("new LRU in-memory store for keys: %w", err)
+	}
+	return func(key string) (chan struct{}, chan struct{}) {
+		keysZoneItem, _ := keysZone.GetOrAdd(key, func() *KeysZoneItem {
+			return &KeysZoneItem{
+				slots:        make(chan struct{}, limit),
+				backlogSlots: make(chan struct{}, limit+backlogLimit),
+			}
+		})
+		return keysZoneItem.slots, keysZoneItem.backlogSlots
+	}, nil
+}

--- a/internal/inflightlimit/request_processor_test.go
+++ b/internal/inflightlimit/request_processor_test.go
@@ -1,0 +1,548 @@
+/*
+Copyright © 2025 Acronis International GmbH.
+
+Released under MIT license.
+*/
+
+package inflightlimit
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+)
+
+// SlotsProviderTestSuite contains tests for slots provider functionality
+type SlotsProviderTestSuite struct {
+	suite.Suite
+}
+
+func TestSlotsProvider(t *testing.T) {
+	suite.Run(t, new(SlotsProviderTestSuite))
+}
+
+func (s *SlotsProviderTestSuite) TestNewSlotsProvider() {
+	tests := []struct {
+		name         string
+		limit        int
+		backlogLimit int
+		maxKeys      int
+		wantErr      bool
+	}{
+		{
+			name:         "with max keys",
+			limit:        5,
+			backlogLimit: 10,
+			maxKeys:      100,
+			wantErr:      false,
+		},
+		{
+			name:         "zero max keys",
+			limit:        5,
+			backlogLimit: 10,
+			maxKeys:      0,
+			wantErr:      false,
+		},
+		{
+			name:         "zero backlog limit",
+			limit:        5,
+			backlogLimit: 0,
+			maxKeys:      100,
+			wantErr:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			provider, err := newSlotsProvider(tt.limit, tt.backlogLimit, tt.maxKeys)
+			if tt.wantErr {
+				s.Error(err)
+				s.Nil(provider)
+				return
+			}
+			s.NoError(err)
+			s.NotNil(provider)
+
+			inFlightSlots, backlogSlots := provider("test-key")
+			s.NotNil(inFlightSlots)
+			s.NotNil(backlogSlots)
+			s.Equal(tt.limit, cap(inFlightSlots))
+			s.Equal(tt.limit+tt.backlogLimit, cap(backlogSlots))
+		})
+	}
+}
+
+func (s *SlotsProviderTestSuite) TestSlotsProvider_SameKeyReturnsSameSlots() {
+	provider, err := newSlotsProvider(5, 10, 0) // maxKeys = 0 means single shared slots
+	s.NoError(err)
+	key := "test-key"
+
+	inFlightSlots1, backlogSlots1 := provider(key)
+	inFlightSlots2, backlogSlots2 := provider(key)
+
+	s.Equal(inFlightSlots1, inFlightSlots2, "same key should return same in-flight slots when maxKeys=0")
+	s.Equal(backlogSlots1, backlogSlots2, "same key should return same backlog slots when maxKeys=0")
+}
+
+func (s *SlotsProviderTestSuite) TestSlotsProvider_DifferentKeysWithLRU() {
+	provider, err := newSlotsProvider(5, 10, 100)
+	s.NoError(err)
+	key1 := "test-key-1"
+	key2 := "test-key-2"
+
+	inFlightSlots1, backlogSlots1 := provider(key1)
+	inFlightSlots2, backlogSlots2 := provider(key2)
+
+	s.NotEqual(inFlightSlots1, inFlightSlots2, "different keys should have different in-flight slots")
+	s.NotEqual(backlogSlots1, backlogSlots2, "different keys should have different backlog slots")
+	s.Equal(5, cap(inFlightSlots1))
+	s.Equal(5, cap(inFlightSlots2))
+	s.Equal(15, cap(backlogSlots1)) // limit + backlogLimit
+	s.Equal(15, cap(backlogSlots2))
+}
+
+// RequestProcessorTestSuite contains tests for RequestProcessor
+type RequestProcessorTestSuite struct {
+	suite.Suite
+}
+
+func TestRequestProcessor(t *testing.T) {
+	suite.Run(t, new(RequestProcessorTestSuite))
+}
+
+func (s *RequestProcessorTestSuite) TestNewRequestProcessor() {
+	tests := []struct {
+		name           string
+		limit          int
+		backlogParams  BacklogParams
+		dryRun         bool
+		wantErr        bool
+		expectedErrMsg string
+	}{
+		{
+			name:  "valid parameters",
+			limit: 5,
+			backlogParams: BacklogParams{
+				MaxKeys: 100,
+				Limit:   10,
+				Timeout: time.Second,
+			},
+			dryRun:  false,
+			wantErr: false,
+		},
+		{
+			name:  "zero backlog limit",
+			limit: 5,
+			backlogParams: BacklogParams{
+				MaxKeys: 100,
+				Limit:   0,
+				Timeout: time.Second,
+			},
+			dryRun:  false,
+			wantErr: false,
+		},
+		{
+			name:  "zero limit",
+			limit: 0,
+			backlogParams: BacklogParams{
+				MaxKeys: 100,
+				Limit:   10,
+				Timeout: time.Second,
+			},
+			dryRun:         false,
+			wantErr:        true,
+			expectedErrMsg: "limit should be positive",
+		},
+		{
+			name:  "negative limit",
+			limit: -1,
+			backlogParams: BacklogParams{
+				MaxKeys: 100,
+				Limit:   10,
+				Timeout: time.Second,
+			},
+			dryRun:         false,
+			wantErr:        true,
+			expectedErrMsg: "limit should be positive",
+		},
+		{
+			name:  "negative backlog limit",
+			limit: 5,
+			backlogParams: BacklogParams{
+				MaxKeys: 100,
+				Limit:   -1,
+				Timeout: time.Second,
+			},
+			dryRun:         false,
+			wantErr:        true,
+			expectedErrMsg: "backlog limit should not be negative",
+		},
+		{
+			name:  "negative max keys",
+			limit: 5,
+			backlogParams: BacklogParams{
+				MaxKeys: -1,
+				Limit:   10,
+				Timeout: time.Second,
+			},
+			dryRun:         false,
+			wantErr:        true,
+			expectedErrMsg: "max keys for backlog should not be negative",
+		},
+		{
+			name:  "zero timeout uses default",
+			limit: 5,
+			backlogParams: BacklogParams{
+				MaxKeys: 100,
+				Limit:   10,
+				Timeout: 0,
+			},
+			dryRun:  false,
+			wantErr: false,
+		},
+		{
+			name:  "dry run mode",
+			limit: 5,
+			backlogParams: BacklogParams{
+				MaxKeys: 100,
+				Limit:   10,
+				Timeout: time.Second,
+			},
+			dryRun:  true,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			processor, err := NewRequestProcessor(tt.limit, tt.backlogParams, tt.dryRun)
+			if tt.wantErr {
+				s.Error(err)
+				s.Contains(err.Error(), tt.expectedErrMsg)
+				s.Nil(processor)
+				return
+			}
+			s.NoError(err)
+			s.NotNil(processor)
+			s.Equal(tt.limit, processor.limit)
+			s.NotNil(processor.getSlots)
+			s.Equal(tt.dryRun, processor.dryRun)
+			expectedTimeout := tt.backlogParams.Timeout
+			if expectedTimeout == 0 {
+				expectedTimeout = DefaultInFlightLimitBacklogTimeout
+			}
+			s.Equal(expectedTimeout, processor.backlogTimeout)
+		})
+	}
+}
+
+func (s *RequestProcessorTestSuite) TestProcessRequest() {
+	tests := []struct {
+		name                string
+		limit               int
+		backlogParams       BacklogParams
+		dryRun              bool
+		requestHandler      *mockRequestHandler
+		expectedError       string
+		expectedExecuteCall bool
+	}{
+		{
+			name:  "bypass in-flight limiting",
+			limit: 1,
+			backlogParams: BacklogParams{
+				MaxKeys: 100,
+				Limit:   0,
+				Timeout: time.Second,
+			},
+			dryRun: false,
+			requestHandler: &mockRequestHandler{
+				key:    "test-key",
+				bypass: true,
+			},
+			expectedExecuteCall: true,
+		},
+		{
+			name:  "allow request immediately",
+			limit: 5,
+			backlogParams: BacklogParams{
+				MaxKeys: 100,
+				Limit:   10,
+				Timeout: time.Second,
+			},
+			dryRun: false,
+			requestHandler: &mockRequestHandler{
+				key:    "test-key",
+				bypass: false,
+			},
+			expectedExecuteCall: true,
+		},
+		{
+			name:  "get key error",
+			limit: 5,
+			backlogParams: BacklogParams{
+				MaxKeys: 100,
+				Limit:   10,
+				Timeout: time.Second,
+			},
+			dryRun: false,
+			requestHandler: &mockRequestHandler{
+				keyError: errors.New("key error"),
+			},
+			expectedError:       "get key for in-flight limit: key error",
+			expectedExecuteCall: false,
+		},
+		{
+			name:  "dry run mode allows immediate execution",
+			limit: 1,
+			backlogParams: BacklogParams{
+				MaxKeys: 100,
+				Limit:   10,
+				Timeout: time.Second,
+			},
+			dryRun: true,
+			requestHandler: &mockRequestHandler{
+				key:    "test-key",
+				bypass: false,
+			},
+			expectedExecuteCall: true,
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			processor, err := NewRequestProcessor(tt.limit, tt.backlogParams, tt.dryRun)
+			s.NoError(err)
+
+			err = processor.ProcessRequest(tt.requestHandler)
+
+			if tt.expectedError != "" {
+				s.Error(err)
+				s.Contains(err.Error(), tt.expectedError)
+			} else {
+				s.NoError(err)
+			}
+
+			s.Equal(tt.expectedExecuteCall, tt.requestHandler.executeCalled)
+		})
+	}
+}
+
+func (s *RequestProcessorTestSuite) TestProcessRequest_BacklogFull() {
+	processor, err := NewRequestProcessor(1, BacklogParams{
+		MaxKeys: 0, // Single shared backlog
+		Limit:   0, // No backlog
+		Timeout: time.Second,
+	}, false)
+	s.NoError(err)
+
+	// Fill the single in-flight slot and the backlog slot (capacity is limit + backlogLimit = 1 + 0 = 1)
+	inFlightSlots, backlogSlots := processor.getSlots("test-key")
+	inFlightSlots <- struct{}{}
+	backlogSlots <- struct{}{} // Fill the single backlog slot
+
+	requestHandler := &mockRequestHandler{
+		key:    "test-key",
+		bypass: false,
+	}
+
+	err = processor.ProcessRequest(requestHandler)
+	s.NoError(err)
+	s.False(requestHandler.executeCalled)
+	s.True(requestHandler.onRejectCalled)
+	s.Equal("test-key", requestHandler.lastParams.Key)
+	s.False(requestHandler.lastParams.RequestBacklogged)
+}
+
+func (s *RequestProcessorTestSuite) TestProcessRequest_WithBacklog() {
+	processor, err := NewRequestProcessor(1, BacklogParams{
+		MaxKeys: 0, // Single shared backlog
+		Limit:   2,
+		Timeout: time.Millisecond * 100,
+	}, false)
+	s.NoError(err)
+
+	// Fill the single in-flight slot
+	inFlightSlots, _ := processor.getSlots("test-key")
+	inFlightSlots <- struct{}{}
+
+	requestHandler := &mockRequestHandler{
+		key:    "test-key",
+		bypass: false,
+	}
+
+	// Start a goroutine to release the in-flight slot after a short delay
+	go func() {
+		time.Sleep(time.Millisecond * 50)
+		<-inFlightSlots
+	}()
+
+	start := time.Now()
+	err = processor.ProcessRequest(requestHandler)
+	duration := time.Since(start)
+
+	s.NoError(err)
+	s.True(requestHandler.executeCalled)
+	s.GreaterOrEqual(duration, time.Millisecond*40) // Allow some tolerance
+}
+
+func (s *RequestProcessorTestSuite) TestProcessRequest_BacklogTimeout() {
+	processor, err := NewRequestProcessor(1, BacklogParams{
+		MaxKeys: 0, // Single shared backlog
+		Limit:   2,
+		Timeout: time.Millisecond * 100,
+	}, false)
+	s.NoError(err)
+
+	// Fill the single in-flight slot
+	inFlightSlots, _ := processor.getSlots("test-key")
+	inFlightSlots <- struct{}{}
+
+	requestHandler := &mockRequestHandler{
+		key:    "test-key",
+		bypass: false,
+	}
+
+	start := time.Now()
+	err = processor.ProcessRequest(requestHandler)
+	duration := time.Since(start)
+
+	s.NoError(err)
+	s.False(requestHandler.executeCalled)
+	s.True(requestHandler.onRejectCalled)
+	s.Equal("test-key", requestHandler.lastParams.Key)
+	s.True(requestHandler.lastParams.RequestBacklogged)
+	s.GreaterOrEqual(duration, time.Millisecond*90) // Allow tolerance
+	s.LessOrEqual(duration, time.Millisecond*200)
+}
+
+func (s *RequestProcessorTestSuite) TestProcessRequest_ContextCancellation() {
+	processor, err := NewRequestProcessor(1, BacklogParams{
+		MaxKeys: 0, // Single shared backlog
+		Limit:   2,
+		Timeout: time.Second * 10,
+	}, false)
+	s.NoError(err)
+
+	// Fill the single in-flight slot
+	inFlightSlots, _ := processor.getSlots("test-key")
+	inFlightSlots <- struct{}{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	requestHandler := &mockRequestHandler{
+		ctx:    ctx,
+		key:    "test-key",
+		bypass: false,
+	}
+
+	go func() {
+		time.Sleep(time.Millisecond * 100)
+		cancel()
+	}()
+
+	start := time.Now()
+	err = processor.ProcessRequest(requestHandler)
+	duration := time.Since(start)
+
+	s.Error(err)
+	s.Contains(err.Error(), "context canceled")
+	s.False(requestHandler.executeCalled)
+	s.True(requestHandler.onErrorCalled)
+	s.Equal("test-key", requestHandler.lastParams.Key)
+	s.True(requestHandler.lastParams.RequestBacklogged)
+	s.GreaterOrEqual(duration, time.Millisecond*90) // Allow tolerance
+	s.LessOrEqual(duration, time.Millisecond*200)
+}
+
+func (s *RequestProcessorTestSuite) TestProcessRequest_DryRunRejectWhenSlotsFull() {
+	processor, err := NewRequestProcessor(1, BacklogParams{
+		MaxKeys: 0, // Single shared backlog
+		Limit:   2,
+		Timeout: time.Second,
+	}, true) // Dry run mode
+	s.NoError(err)
+
+	// Fill the single in-flight slot
+	inFlightSlots, _ := processor.getSlots("test-key")
+	inFlightSlots <- struct{}{}
+
+	requestHandler := &mockRequestHandler{
+		key:    "test-key",
+		bypass: false,
+	}
+
+	err = processor.ProcessRequest(requestHandler)
+	s.NoError(err)
+	s.False(requestHandler.executeCalled)
+	s.True(requestHandler.onRejectCalled)
+	s.Equal("test-key", requestHandler.lastParams.Key)
+	s.True(requestHandler.lastParams.RequestBacklogged)
+}
+
+func (s *RequestProcessorTestSuite) TestProcessRequest_ExecuteError() {
+	processor, err := NewRequestProcessor(5, BacklogParams{
+		MaxKeys: 100,
+		Limit:   10,
+		Timeout: time.Second,
+	}, false)
+	s.NoError(err)
+
+	executeErr := errors.New("execute error")
+	requestHandler := &mockRequestHandler{
+		key:          "test-key",
+		bypass:       false,
+		executeError: executeErr,
+	}
+
+	err = processor.ProcessRequest(requestHandler)
+	s.Error(err)
+	s.Equal(executeErr, err)
+	s.True(requestHandler.executeCalled)
+}
+
+// Helper functions and mocks
+
+// mockRequestHandler implements the RequestHandler interface for testing
+type mockRequestHandler struct {
+	ctx            context.Context
+	key            string
+	bypass         bool
+	keyError       error
+	executeError   error
+	executeCalled  bool
+	onRejectCalled bool
+	onErrorCalled  bool
+	lastParams     Params
+	lastError      error
+}
+
+func (m *mockRequestHandler) GetContext() context.Context {
+	if m.ctx != nil {
+		return m.ctx
+	}
+	return context.Background()
+}
+
+func (m *mockRequestHandler) GetKey() (string, bool, error) {
+	return m.key, m.bypass, m.keyError
+}
+
+func (m *mockRequestHandler) Execute() error {
+	m.executeCalled = true
+	return m.executeError
+}
+
+func (m *mockRequestHandler) OnReject(params Params) error {
+	m.onRejectCalled = true
+	m.lastParams = params
+	return nil
+}
+
+func (m *mockRequestHandler) OnError(params Params, err error) error {
+	m.onErrorCalled = true
+	m.lastParams = params
+	m.lastError = err
+	return err
+}

--- a/internal/ratelimit/doc.go
+++ b/internal/ratelimit/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright © 2025 Acronis International GmbH.
+
+Released under MIT license.
+*/
+
+// Package ratelimit provides rate limiting functionality to control the rate
+// at which requests are processed over time.
+//
+// The package implements a generic RequestProcessor that can be used with both HTTP
+// and gRPC requests to enforce rate limits with optional backlog queuing.
+// When rate limits are exceeded, requests can be queued in a backlog with
+// configurable timeout, or rejected immediately if the backlog is full.
+//
+// Key features:
+//   - Token bucket and sliding window rate limiting algorithms
+//   - Configurable rate limits per key or globally
+//   - Optional backlog queuing with timeout and retry-after headers
+//   - LRU-based key management for memory efficiency
+//   - Integration with external rate limiters via Limiter interface
+package ratelimit

--- a/internal/ratelimit/go.doc.go
+++ b/internal/ratelimit/go.doc.go
@@ -1,8 +1,0 @@
-/*
-Copyright © 2025 Acronis International GmbH.
-
-Released under MIT license.
-*/
-
-// Package ratelimit provides rate limiting functionality.
-package ratelimit


### PR DESCRIPTION
- Add InFlightLimitUnaryInterceptor and InFlightLimitStreamInterceptor with configurable options
- Implement key-based limiting, backlog support, dry-run mode, and retry-after headers
- Add extensive test coverage for concurrent requests, key-based limiting, and error scenarios
- Include internal request processor with timeout handling and resource management