### PR TITLE
feat: add library version labels to Prometheus metrics

### DIFF
--- a/grpcserver/interceptor/metrics_interceptor.go
+++ b/grpcserver/interceptor/metrics_interceptor.go
@@ -14,6 +14,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/acronis/go-appkit/internal/libinfo"
 )
 
 const (
@@ -127,7 +129,7 @@ func NewPrometheusMetrics(opts ...PrometheusOption) *PrometheusMetrics {
 			Name:        "grpc_call_duration_seconds",
 			Help:        "A histogram of the gRPC call durations.",
 			Buckets:     config.durationBuckets,
-			ConstLabels: config.constLabels,
+			ConstLabels: libinfo.AddPrometheusLibVersionLabel(config.constLabels),
 		},
 		makeLabelNames(
 			callMetricsLabelService,
@@ -143,7 +145,7 @@ func NewPrometheusMetrics(opts ...PrometheusOption) *PrometheusMetrics {
 			Namespace:   config.namespace,
 			Name:        "grpc_calls_in_flight",
 			Help:        "Current number of gRPC calls being served.",
-			ConstLabels: config.constLabels,
+			ConstLabels: libinfo.AddPrometheusLibVersionLabel(config.constLabels),
 		},
 		makeLabelNames(
 			callMetricsLabelService,

--- a/httpclient/metrics_round_tripper.go
+++ b/httpclient/metrics_round_tripper.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/acronis/go-appkit/internal/libinfo"
 )
 
 // MetricsCollector is an interface for collecting metrics for client requests.
@@ -35,6 +37,9 @@ func NewPrometheusMetricsCollector(namespace string) *PrometheusMetricsCollector
 			Name:      "http_client_request_duration_seconds",
 			Help:      "A histogram of the http client requests durations.",
 			Buckets:   []float64{0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 150, 300, 600},
+			ConstLabels: prometheus.Labels{
+				libinfo.PrometheusLibVersionLabel: libinfo.GetLibVersion(),
+			},
 		}, []string{"client_type", "remote_address", "summary", "status", "request_type"}),
 	}
 }

--- a/httpserver/middleware/metrics.go
+++ b/httpserver/middleware/metrics.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/acronis/go-appkit/internal/libinfo"
 )
 
 const (
@@ -96,7 +98,7 @@ func NewHTTPRequestPrometheusMetricsWithOpts(opts HTTPRequestPrometheusMetricsOp
 			Name:        "http_request_duration_seconds",
 			Help:        "A histogram of the HTTP request durations.",
 			Buckets:     durBuckets,
-			ConstLabels: opts.ConstLabels,
+			ConstLabels: libinfo.AddPrometheusLibVersionLabel(opts.ConstLabels),
 		},
 		makeLabelNames(
 			httpRequestMetricsLabelMethod,
@@ -111,7 +113,7 @@ func NewHTTPRequestPrometheusMetricsWithOpts(opts HTTPRequestPrometheusMetricsOp
 			Namespace:   opts.Namespace,
 			Name:        "http_requests_in_flight",
 			Help:        "Current number of HTTP requests being served.",
-			ConstLabels: opts.ConstLabels,
+			ConstLabels: libinfo.AddPrometheusLibVersionLabel(opts.ConstLabels),
 		},
 		makeLabelNames(
 			httpRequestMetricsLabelMethod,

--- a/internal/libinfo/doc.go
+++ b/internal/libinfo/doc.go
@@ -1,0 +1,8 @@
+/*
+Copyright © 2025 Acronis International GmbH.
+
+Released under MIT license.
+*/
+
+// Package libinfo provides helpers for working with the library information.
+package libinfo

--- a/internal/libinfo/version.go
+++ b/internal/libinfo/version.go
@@ -1,0 +1,68 @@
+/*
+Copyright © 2024 Acronis International GmbH.
+
+Released under MIT license.
+*/
+
+package libinfo
+
+import (
+	"debug/buildinfo"
+	"regexp"
+	"sync"
+
+	"runtime/debug"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const libShortName = "go-appkit"
+
+const moduleName = "github.com/acronis/" + libShortName
+
+const PrometheusLibVersionLabel = "go_appkit_version"
+
+func AddPrometheusLibVersionLabel(labels prometheus.Labels) prometheus.Labels {
+	labelsCopy := make(prometheus.Labels, len(labels))
+	for k, v := range labels {
+		labelsCopy[k] = v
+	}
+	labelsCopy[PrometheusLibVersionLabel] = GetLibVersion()
+	return labelsCopy
+}
+
+var libVersion string
+var libVersionOnce sync.Once
+
+func GetLibVersion() string {
+	libVersionOnce.Do(initLibVersion)
+	return libVersion
+}
+
+func initLibVersion() {
+	if buildInfo, ok := debug.ReadBuildInfo(); ok {
+		libVersion = extractLibVersion(buildInfo, moduleName)
+	}
+	if libVersion == "" {
+		libVersion = "v0.0.0"
+	}
+}
+
+// extractLibVersion extracts the version of the given module from the build info.
+// It expects the module name to be in the form "moduleName" or "moduleName/vX" where X is a major version number.
+// This format is used by Go modules to indicate major version changes.
+func extractLibVersion(buildInfo *buildinfo.BuildInfo, modName string) string {
+	if buildInfo == nil {
+		return ""
+	}
+	re, err := regexp.Compile(`^` + regexp.QuoteMeta(modName) + `(/v[0-9]+)?$`)
+	if err != nil {
+		return "" // should never happen
+	}
+	for _, dep := range buildInfo.Deps {
+		if re.MatchString(dep.Path) {
+			return dep.Version
+		}
+	}
+	return ""
+}

--- a/internal/libinfo/version_test.go
+++ b/internal/libinfo/version_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright © 2024 Acronis International GmbH.
+
+Released under MIT license.
+*/
+
+package libinfo
+
+import (
+	"debug/buildinfo"
+	"runtime/debug"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractLibVersion(t *testing.T) {
+	const moduleName = "github.com/acronis/go-appkit"
+
+	tests := []struct {
+		name        string
+		buildInfo   *buildinfo.BuildInfo
+		moduleName  string
+		expectedVer string
+	}{
+		{
+			name: "module found",
+			buildInfo: &buildinfo.BuildInfo{
+				Deps: []*debug.Module{
+					{Path: moduleName, Version: "v1.2.3"},
+				},
+			},
+			moduleName:  moduleName,
+			expectedVer: "v1.2.3",
+		},
+		{
+			name: "module found, v2",
+			buildInfo: &buildinfo.BuildInfo{
+				Deps: []*debug.Module{
+					{Path: moduleName + "/v2", Version: "v2.0.0"},
+				},
+			},
+			moduleName:  moduleName,
+			expectedVer: "v2.0.0",
+		},
+		{
+			name: "module not found",
+			buildInfo: &buildinfo.BuildInfo{
+				Deps: []*debug.Module{
+					{Path: "github.com/other/module", Version: "v1.0.0"},
+				},
+			},
+			moduleName:  moduleName,
+			expectedVer: "",
+		},
+		{
+			name: "empty deps",
+			buildInfo: &buildinfo.BuildInfo{
+				Deps: []*debug.Module{},
+			},
+			moduleName:  moduleName,
+			expectedVer: "",
+		},
+		{
+			name:        "nil build info",
+			buildInfo:   nil,
+			moduleName:  moduleName,
+			expectedVer: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractLibVersion(tt.buildInfo, tt.moduleName)
+			require.Equal(t, tt.expectedVer, got)
+		})
+	}
+}

--- a/internal/throttleconfig/metrics.go
+++ b/internal/throttleconfig/metrics.go
@@ -8,6 +8,8 @@ package throttleconfig
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/acronis/go-appkit/internal/libinfo"
 )
 
 const (
@@ -69,7 +71,7 @@ func NewPrometheusMetricsWithOpts(subsystem string, opts PrometheusMetricsOpts) 
 		Subsystem:   subsystem,
 		Name:        "in_flight_limit_rejects_total",
 		Help:        "Number of rejected requests due to in-flight limit exceeded.",
-		ConstLabels: opts.ConstLabels,
+		ConstLabels: libinfo.AddPrometheusLibVersionLabel(opts.ConstLabels),
 	}, makeLabelNames(metricsLabelDryRun, metricsLabelRule, metricsLabelBacklogged))
 
 	rateLimitRejects := prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -77,7 +79,7 @@ func NewPrometheusMetricsWithOpts(subsystem string, opts PrometheusMetricsOpts) 
 		Subsystem:   subsystem,
 		Name:        "rate_limit_rejects_total",
 		Help:        "Number of rejected requests due to rate limit exceeded.",
-		ConstLabels: opts.ConstLabels,
+		ConstLabels: libinfo.AddPrometheusLibVersionLabel(opts.ConstLabels),
 	}, makeLabelNames(metricsLabelDryRun, metricsLabelRule))
 
 	return &PrometheusMetrics{

--- a/lrucache/metrics.go
+++ b/lrucache/metrics.go
@@ -6,7 +6,11 @@ Released under MIT license.
 
 package lrucache
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/acronis/go-appkit/internal/libinfo"
+)
 
 // MetricsCollector represents a collector of metrics to analyze how (effectively or not) cache is used.
 type MetricsCollector interface {
@@ -59,7 +63,7 @@ func NewPrometheusMetricsWithOpts(opts PrometheusMetricsOpts) *PrometheusMetrics
 			Namespace:   opts.Namespace,
 			Name:        "cache_entries_amount",
 			Help:        "Total number of entries in the cache.",
-			ConstLabels: opts.ConstLabels,
+			ConstLabels: libinfo.AddPrometheusLibVersionLabel(opts.ConstLabels),
 		},
 		opts.CurriedLabelNames,
 	)
@@ -69,7 +73,7 @@ func NewPrometheusMetricsWithOpts(opts PrometheusMetricsOpts) *PrometheusMetrics
 			Namespace:   opts.Namespace,
 			Name:        "cache_hits_total",
 			Help:        "Number of successfully found keys in the cache.",
-			ConstLabels: opts.ConstLabels,
+			ConstLabels: libinfo.AddPrometheusLibVersionLabel(opts.ConstLabels),
 		},
 		opts.CurriedLabelNames,
 	)
@@ -79,7 +83,7 @@ func NewPrometheusMetricsWithOpts(opts PrometheusMetricsOpts) *PrometheusMetrics
 			Namespace:   opts.Namespace,
 			Name:        "cache_misses_total",
 			Help:        "Number of not found keys in cache.",
-			ConstLabels: opts.ConstLabels,
+			ConstLabels: libinfo.AddPrometheusLibVersionLabel(opts.ConstLabels),
 		},
 		opts.CurriedLabelNames,
 	)
@@ -89,7 +93,7 @@ func NewPrometheusMetricsWithOpts(opts PrometheusMetricsOpts) *PrometheusMetrics
 			Namespace:   opts.Namespace,
 			Name:        "cache_evictions_total",
 			Help:        "Number of evicted entries.",
-			ConstLabels: opts.ConstLabels,
+			ConstLabels: libinfo.AddPrometheusLibVersionLabel(opts.ConstLabels),
 		},
 		opts.CurriedLabelNames,
 	)

--- a/restapi/metrics.go
+++ b/restapi/metrics.go
@@ -6,7 +6,11 @@ Released under MIT license.
 
 package restapi
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/acronis/go-appkit/internal/libinfo"
+)
 
 var metricsResponseErrors *prometheus.CounterVec
 
@@ -24,6 +28,9 @@ func MustInitAndRegisterMetrics(namespace string) {
 		Subsystem: metricsSubsystem,
 		Name:      "response_errors",
 		Help:      "The total number of REST API errors that were respond.",
+		ConstLabels: prometheus.Labels{
+			libinfo.PrometheusLibVersionLabel: libinfo.GetLibVersion(),
+		},
 	}, []string{metricsLabelResponseErrorDomain, metricsLabelResponseErrorCode})
 	prometheus.MustRegister(metricsResponseErrors)
 }


### PR DESCRIPTION
- Add internal/libinfo package for managing library version information
- Implement AddPrometheusLibVersionLabel helper function
- Apply go_appkit_version label to all Prometheus metrics