### PR TITLE
docs: add GoDoc badges to README files

### DIFF
--- a/grpcserver/README.md
+++ b/grpcserver/README.md
@@ -1,5 +1,7 @@
 # grpcserver
 
+[![GoDoc Widget]][GoDoc]
+
 A gRPC server implementation with YAML/JSON based configuration, built-in interceptors, and observability features.
 
 ## Features
@@ -62,3 +64,6 @@ The server can be easily configured from JSON/YAML files with options including:
 - Graceful shutdown parameters
 
 See the examples directory for complete configuration examples.
+
+[GoDoc]: https://pkg.go.dev/github.com/acronis/go-appkit/grpcserver
+[GoDoc Widget]: https://godoc.org/github.com/acronis/go-appkit?status.svg

--- a/grpcserver/interceptor/README.md
+++ b/grpcserver/interceptor/README.md
@@ -1,6 +1,8 @@
 # grpcserver/interceptor
 
-A collection of gRPC interceptors for logging, metrics collection, panic recovery, request ID handling, rate limiting, and in-flight limiting. These interceptors enhance gRPC services with observability, reliability, and traffic control features.
+[![GoDoc Widget]][GoDoc]
+
+A collection of gRPC server interceptors for logging, metrics collection, panic recovery, request ID handling, rate limiting, and in-flight limiting. These interceptors enhance gRPC services with observability, reliability, and traffic control features.
 
 See complete working example of using these interceptors in the [Echo Service Example](./../examples/echo-service).
 
@@ -627,3 +629,6 @@ func createGRPCServer(logger log.FieldLogger) *grpc.Server {
    - Avoid keys that could lead to hot spots (e.g., constant values)
    - Consider using multiple levels of rate limiting (global + per-client)
    - Implement bypass logic for internal or privileged clients
+
+[GoDoc]: https://pkg.go.dev/github.com/acronis/go-appkit/grpcserver/interceptor
+[GoDoc Widget]: https://godoc.org/github.com/acronis/go-appkit?status.svg

--- a/grpcserver/interceptor/throttle/README.md
+++ b/grpcserver/interceptor/throttle/README.md
@@ -1,8 +1,8 @@
-# gRPC Interceptor for API Throttling
+# grpcserver/interceptor/throttle
 
-The package provides comprehensive throttling for gRPC services with both rate limiting and in-flight request limiting capabilities. It supports multiple algorithms, flexible configuration, and extensive customization options.
+[![GoDoc Widget]][GoDoc]
 
-The throttling is implemented as standard gRPC interceptors and can be configured from code or from JSON/YAML configuration files.
+A comprehensive gRPC server throttling interceptors with flexible configuration from JSON/YAML files and both rate limiting and in-flight request limiting capabilities.
 
 See complete working example of using configurable gRPC throttling in the [Echo Service Example](./../../examples/echo-service).
 
@@ -545,8 +545,5 @@ Extracts keys from client IP addresses.
 - **Status**: `codes.Internal`
 - **Message**: "Internal server error"
 
-## License
-
-Copyright © 2025 Acronis International GmbH.
-
-Licensed under [MIT License](./../../../../LICENSE).
+[GoDoc]: https://pkg.go.dev/github.com/acronis/go-appkit/grpcserver/interceptor/throttle
+[GoDoc Widget]: https://godoc.org/github.com/acronis/go-appkit?status.svg

--- a/httpclient/README.md
+++ b/httpclient/README.md
@@ -1,8 +1,10 @@
 # httpclient
 
-This package provides a collection of HTTP round trippers that can be chained together to enhance HTTP clients with reliability, observability, and traffic control features.
+[![GoDoc Widget]][GoDoc]
 
-Additionally, it includes a factory function to create HTTP clients with pre-configured round trippers based on YAML/JSON configuration files.
+A collection of HTTP client round trippers that can be chained together to enhance HTTP clients with reliability, observability, and traffic control features.
+
+Additionally, the package includes a factory function to create HTTP clients with pre-configured round trippers based on YAML/JSON configuration files.
 
 ## Table of Contents
 
@@ -288,10 +290,10 @@ client := &http.Client{Transport: transport}
 
 ## Client Factory and Configuration
 
-The package provides factory functions to create HTTP clients with pre-configured round trippers. Configuration can be loaded from YAML files, environment variables, or defined programmatically.
+The package provides factory functions to create HTTP clients with pre-configured round trippers. Configuration can be loaded from YAML, JSON, environment variables, or defined programmatically.
 
 **Configuration can be loaded from:**
-- YAML/JSON files using unmarshalling
+- YAML/JSON data using unmarshalling
 - YAML/JSON files and/or environment variables using `config.Loader`
 - Direct struct initialization
 
@@ -369,3 +371,6 @@ func createClientFromYAML() (*http.Client, error) {
     })
 }
 ```
+
+[GoDoc]: https://pkg.go.dev/github.com/acronis/go-appkit/httpclient
+[GoDoc Widget]: https://godoc.org/github.com/acronis/go-appkit?status.svg

--- a/httpserver/middleware/throttle/README.md
+++ b/httpserver/middleware/throttle/README.md
@@ -1,10 +1,21 @@
-# HTTP middleware for API throttling
+# httpserver/middleware/throttle
 
-The package provides two types of server-side throttling for HTTP services:
-1. In-flight throttling limits the total number of currently served (in-flight) HTTP requests.
-2. Rate-limit throttling limits the rate of HTTP requests using the leaky bucket or the sliding window algorithms (it's configurable, the leaky bucket is used by default).
+[![GoDoc Widget]][GoDoc]
 
-Throttling is implemented as a typical Go HTTP middleware and can be configured from the code or from the JSON/YAML configuration file.
+A comprehensive HTTP request throttling middleware with flexible configuration from JSON/YAML files and both rate limiting and in-flight request limiting capabilities.
+
+## Features
+
+- **Rate Limiting**: Controls the frequency of requests over time using leaky bucket (with burst support) or sliding window algorithms
+- **In-Flight Limiting**: Controls the number of concurrent requests being processed
+- **Flexible Key Extraction**: Global, per-client IP, per-header value, or custom identity-based throttling
+- **Nginx-style Route Matching**: Location-based route selection with exact matches and patterns
+- **Request Backlogging**: Queue requests when limits are reached with configurable timeouts
+- **Dry-Run Mode**: Test throttling configurations without enforcement
+- **Comprehensive Metrics**: Prometheus metrics for monitoring and alerting
+- **Tag-Based Rules**: Apply different throttling rules to different middleware instances
+- **Key Filtering**: Include/exclude specific keys with glob pattern support
+- **Auto Retry-After**: Automatic calculation of retry intervals for rate limits
 
 Please see [testable example](./example_test.go) to understand how to configure and use the middleware.
 
@@ -287,8 +298,5 @@ For in-flight limiting:
 {"msg": "too many in-flight requests, serving will be continued because of dry run mode", "in_flight_limit_key": "3c00e780-5721-59f8-acad-f0bf719777d4"}
 ```
 
-## License
-
-Copyright © 2024 Acronis International GmbH.
-
-Licensed under [MIT License](./../../../LICENSE).
+[GoDoc]: https://pkg.go.dev/github.com/acronis/go-appkit/httpserver/middleware/throttle
+[GoDoc Widget]: https://godoc.org/github.com/acronis/go-appkit?status.svg

--- a/lrucache/README.md
+++ b/lrucache/README.md
@@ -1,8 +1,8 @@
-# LRUCache
+# lrucache
 
 [![GoDoc Widget]][GoDoc]
 
-The `lrucache` package provides an in-memory cache with an LRU (Least Recently Used) eviction policy and Prometheus metrics integration.
+An in-memory cache with an LRU (Least Recently Used) eviction policy and Prometheus metrics integration.
 
 ## Features
 
@@ -131,12 +131,6 @@ Here is the full list of Prometheus metrics exposed by the `lrucache` package:
 - `cache_evictions_total`: Number of evicted entries.
 
 These metrics can be further customized with namespaces, constant labels, and curried labels as shown in the examples.
-
-## License
-
-Copyright © 2024 Acronis International GmbH.
-
-Licensed under [MIT License](./../LICENSE).
 
 [GoDoc]: https://pkg.go.dev/github.com/acronis/go-appkit/lrucache
 [GoDoc Widget]: https://godoc.org/github.com/acronis/go-appkit?status.svg


### PR DESCRIPTION
- Add GoDoc widgets and links to grpcserver, httpclient, and throttle packages
- Standardize README titles to use package names
- Remove license sections in favor of root LICENSE file
- Enhance package descriptions for better clarity