### PR TITLE
feat(service): add StopTimeout option to wait for Unit.Start to exit

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -12,13 +12,21 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/acronis/go-appkit/log"
 )
 
 // Opts represents an options for Service.
 type Opts struct {
+	// ShutdownSignals is the list of OS signals that trigger a graceful
+	// shutdown of the Service when received. New defaults to SIGINT and SIGTERM.
 	ShutdownSignals []os.Signal
+
+	// StopTimeout, when greater than zero, makes StartContext wait for the
+	// Unit's Start goroutine to exit before returning, up to this duration.
+	// Zero means do not wait.
+	StopTimeout time.Duration
 }
 
 // Service represents a service which can register metrics in Prometheus client,
@@ -48,12 +56,25 @@ func NewWithOpts(logger log.FieldLogger, unit Unit, opts Opts) *Service {
 }
 
 // Start wraps StartContext using the background context.
+// See StartContext for the full description of the return-timing semantics,
+// in particular how Opts.StopTimeout affects when this method returns.
 func (s *Service) Start() error {
 	return s.StartContext(context.Background())
 }
 
-// StartContext starts service unit in the separate goroutine and
-// blocks until fatal error occurs or any of the OS shutting down signals are received.
+// StartContext starts the service Unit in a separate goroutine and blocks
+// until one of the following happens:
+//   - ctx is canceled — Unit.Stop(true) is called;
+//   - Unit reports a fatal error on its error channel — returned as an error;
+//   - one of Opts.ShutdownSignals is received — Unit.Stop(true) is called.
+//
+// Return-timing depends on Opts.StopTimeout:
+//   - 0 (default): returns once the trigger is handled. Synchronizing
+//     Start's exit is up to the Unit's Stop, otherwise Start may outlive
+//     StartContext.
+//   - > 0: additionally waits for Unit.Start to exit, up to StopTimeout;
+//     on timeout returns anyway and logs a warning. Recommended when Stop
+//     does not itself guarantee Start has unwound.
 func (s *Service) StartContext(ctx context.Context) error {
 	if mr, ok := s.Unit.(MetricsRegisterer); ok {
 		mr.MustRegisterMetrics()
@@ -61,26 +82,40 @@ func (s *Service) StartContext(ctx context.Context) error {
 	}
 
 	fatalError := make(chan error, 1)
+	done := make(chan struct{})
 
-	go s.Unit.Start(fatalError)
+	go func() {
+		defer close(done)
+		s.Unit.Start(fatalError)
+	}()
 
 	signal.Notify(s.Signals, s.Opts.ShutdownSignals...)
 
+	var retErr error
 	select {
 	case <-ctx.Done():
 		s.Logger.Info("context is canceled, service will be stopped")
 		if err := s.Unit.Stop(true); err != nil {
-			return fmt.Errorf("stop service gracefully: %w", err)
+			retErr = fmt.Errorf("stop service gracefully: %w", err)
 		}
 	case err := <-fatalError:
 		s.Logger.Error("service fatal error", log.Error(err))
-		return fmt.Errorf("fatal error: %w", err)
+		retErr = fmt.Errorf("fatal error: %w", err)
 	case sig := <-s.Signals:
 		s.Logger.Info("service got signal", log.String("signal", sig.String()))
 		if err := s.Unit.Stop(true); err != nil {
-			return fmt.Errorf("stop service gracefully: %w", err)
+			retErr = fmt.Errorf("stop service gracefully: %w", err)
 		}
 	}
 
-	return nil
+	if s.Opts.StopTimeout > 0 {
+		select {
+		case <-done:
+		case <-time.After(s.Opts.StopTimeout):
+			s.Logger.Warn("unit's Start did not exit within stop timeout",
+				log.String("timeout", s.Opts.StopTimeout.String()))
+		}
+	}
+
+	return retErr
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -55,3 +55,120 @@ func TestService_StartContext(t *testing.T) {
 	require.NoError(t, waitTrue(func() bool { return atomic.LoadInt32(&runningCounter) == 0 }, time.Second*3))
 	require.Equal(t, 1, mockUnit.stopGracefullyCalled)
 }
+
+// controlledUnit allows tests to precisely orchestrate the lifecycle of Start/Stop.
+type controlledUnit struct {
+	startEntered chan struct{}
+	releaseStart chan struct{}
+	stopCalled   chan struct{}
+}
+
+func newControlledUnit() *controlledUnit {
+	return &controlledUnit{
+		startEntered: make(chan struct{}),
+		releaseStart: make(chan struct{}),
+		stopCalled:   make(chan struct{}),
+	}
+}
+
+func (u *controlledUnit) Start(_ chan<- error) {
+	close(u.startEntered)
+	<-u.releaseStart
+}
+
+func (u *controlledUnit) Stop(_ bool) error {
+	close(u.stopCalled)
+	return nil
+}
+
+func TestService_StartContext_StopTimeout_WaitsForStartToExit(t *testing.T) {
+	logRecorder := logtest.NewRecorder()
+	unit := newControlledUnit()
+	svc := NewWithOpts(logRecorder, unit, Opts{StopTimeout: 5 * time.Second})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	returned := make(chan error, 1)
+	go func() {
+		returned <- svc.StartContext(ctx)
+	}()
+
+	<-unit.startEntered
+	cancel()
+	<-unit.stopCalled
+
+	// Start is still blocked — StartContext must NOT have returned yet.
+	select {
+	case err := <-returned:
+		t.Fatalf("StartContext returned before Unit.Start exited: err=%v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(unit.releaseStart)
+
+	select {
+	case err := <-returned:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("StartContext did not return after Unit.Start exited")
+	}
+}
+
+func TestService_StartContext_StopTimeout_ExceededReturns(t *testing.T) {
+	logRecorder := logtest.NewRecorder()
+	unit := newControlledUnit()
+	svc := NewWithOpts(logRecorder, unit, Opts{StopTimeout: 100 * time.Millisecond})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	returned := make(chan error, 1)
+	go func() {
+		returned <- svc.StartContext(ctx)
+	}()
+
+	<-unit.startEntered
+	cancel()
+
+	startTime := time.Now()
+	select {
+	case err := <-returned:
+		require.NoError(t, err)
+		elapsed := time.Since(startTime)
+		require.GreaterOrEqual(t, elapsed, 100*time.Millisecond)
+		require.Less(t, elapsed, time.Second)
+	case <-time.After(time.Second):
+		t.Fatal("StartContext did not return within StopTimeout")
+	}
+
+	// Release Start to avoid leaking the goroutine across tests.
+	close(unit.releaseStart)
+}
+
+func TestService_StartContext_ZeroStopTimeout_DoesNotWait(t *testing.T) {
+	logRecorder := logtest.NewRecorder()
+	unit := newControlledUnit()
+	svc := New(logRecorder, unit) // StopTimeout = 0
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	returned := make(chan error, 1)
+	go func() {
+		returned <- svc.StartContext(ctx)
+	}()
+
+	<-unit.startEntered
+	cancel()
+
+	// With StopTimeout=0, StartContext must return without waiting on Start.
+	select {
+	case err := <-returned:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("StartContext did not return with StopTimeout=0")
+	}
+
+	close(unit.releaseStart)
+}


### PR DESCRIPTION
StartContext previously returned as soon as Unit.Stop completed, leaving the Start goroutine running in the background. The new Opts.StopTimeout, when > 0, makes StartContext block up to the configured duration for Start to exit, logging a warning on timeout. Zero preserves the prior non-waiting behavior.