### PR TITLE
Support custom label names for http request metrics.

### DIFF
--- a/httpserver/http_server.go
+++ b/httpserver/http_server.go
@@ -42,9 +42,10 @@ type APIRoute = func(router chi.Router)
 // HTTPRequestMetricsOpts represents options for HTTPRequestMetricsOpts middleware that used in HTTPServer.
 type HTTPRequestMetricsOpts struct {
 	// Metrics opts.
-	Namespace       string
-	DurationBuckets []float64
-	ConstLabels     prometheus.Labels
+	Namespace        string
+	DurationBuckets  []float64
+	ConstLabels      prometheus.Labels
+	CustomLabelNames []string
 
 	// Middleware opts.
 	// Deprecated: GetUserAgentType be removed in the next major version. Please use CustomLabels with Context instead.
@@ -121,9 +122,10 @@ func New(cfg *Config, logger log.FieldLogger, opts Opts) (*HTTPServer, error) { 
 
 	httpReqPromMetrics := middleware.NewHTTPRequestPrometheusMetricsWithOpts(
 		middleware.HTTPRequestPrometheusMetricsOpts{
-			Namespace:       opts.HTTPRequestMetrics.Namespace,
-			DurationBuckets: opts.HTTPRequestMetrics.DurationBuckets,
-			ConstLabels:     opts.HTTPRequestMetrics.ConstLabels,
+			Namespace:        opts.HTTPRequestMetrics.Namespace,
+			DurationBuckets:  opts.HTTPRequestMetrics.DurationBuckets,
+			ConstLabels:      opts.HTTPRequestMetrics.ConstLabels,
+			CustomLabelNames: opts.HTTPRequestMetrics.CustomLabelNames,
 		})
 	router := chi.NewRouter()
 	if err := applyDefaultMiddlewaresToRouter(router, cfg, logger, opts, httpReqPromMetrics); err != nil {

--- a/httpserver/http_server_test.go
+++ b/httpserver/http_server_test.go
@@ -774,3 +774,54 @@ func TestHTTPServer_NewWithAPIRoutesHasMetrics(t *testing.T) {
 	defer func() { require.NoError(t, resp.Body.Close()) }()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 }
+
+func TestHTTPServer_HTTPRequestMetricsCustomLabelNames(t *testing.T) {
+	const customLabelName = "cross_dc_request"
+
+	addr := testutil.GetLocalAddrWithFreeTCPPort()
+
+	apiRoutes := map[APIVersion]APIRoute{
+		1: func(router chi.Router) {
+			router.Get("/test", func(rw http.ResponseWriter, r *http.Request) {
+				mp := middleware.GetMetricsParamsFromContext(r.Context())
+				mp.SetValue(customLabelName, "true")
+				logger := middleware.GetLoggerFromContext(r.Context())
+				restapi.RespondJSON(rw, map[string]string{"message": "test"}, logger)
+			})
+		},
+	}
+
+	httpServer, err := New(&Config{Address: addr}, logtest.NewLogger(), Opts{
+		ServiceNameInURL: "test-service",
+		APIRoutes:        apiRoutes,
+		HTTPRequestMetrics: HTTPRequestMetricsOpts{
+			CustomLabelNames: []string{customLabelName},
+		},
+	})
+	require.NoError(t, err)
+	httpServer.MustRegisterMetrics()
+	defer httpServer.UnregisterMetrics()
+
+	fatalErr := make(chan error, 1)
+	go httpServer.Start(fatalErr)
+	require.NoError(t, testutil.WaitListeningServer(addr, time.Second*3))
+	defer func() {
+		require.NoError(t, httpServer.Stop(false))
+		testutil.RequireNoErrorInChannel(t, fatalErr)
+	}()
+
+	resp, err := http.Get(httpServer.URL + "/api/test-service/v1/test")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp, err = http.Get(httpServer.URL + "/metrics")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	require.Contains(t, string(respBody), `cross_dc_request="true"`,
+		"custom label registered via HTTPRequestMetricsOpts.CustomLabelNames must be present in the metrics output")
+}


### PR DESCRIPTION
Support custom label names for http request metrics.

Without this change, custom metrics labels set with `MetricsParams.SetValue` do not appear in prometheus because these label names are not registered.